### PR TITLE
Log blocks for Travis CI

### DIFF
--- a/build/shade/BuildEnv.shade
+++ b/build/shade/BuildEnv.shade
@@ -41,4 +41,15 @@ functions
             return Environment.GetEnvironmentVariable("KOREBUILD_FOLDER"); 
         }
     }
-  }
+
+    bool IsTeamCity
+    {
+        get { return !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("TEAMCITY_VERSION")); }
+    }
+
+    bool IsTravisCi
+    {
+        get { return !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("TRAVIS")) &&
+                !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("CONTINUOUS_INTEGRATION")); }
+    }
+}

--- a/build/shade/_k-standard-goals.shade
+++ b/build/shade/_k-standard-goals.shade
@@ -8,7 +8,7 @@ use import="BuildEnv"
 use import="Environment"
 use import="Files"
 use import="Json"
-use-teamcity
+use-ci-loggers
 
 default BASE_DIR='${Directory.GetCurrentDirectory()}'
 default TARGET_DIR='${Path.Combine(BASE_DIR, "artifacts")}'

--- a/build/shade/_use-ci-loggers.shade
+++ b/build/shade/_use-ci-loggers.shade
@@ -1,0 +1,125 @@
+functions
+    @{
+        // NB: this cannot be used alongside 'use-teamcity' because they both override StartingTarget(string)
+        public interface IBlockLogger
+        {
+            void EndBlock(string name);
+            void StartBlock(string name);
+        }
+
+        class TravisCiLogger : Sake.Engine.Logging.DefaultLog, IBlockLogger
+        {
+            public TravisCiLogger(Sake.Engine.ISakeSettings settings)
+                :base(settings)
+            {
+            }
+
+            public void EndBlock(string name)
+            {
+                Console.WriteLine("travis_fold:end:" + name);
+            }
+
+            public void StartBlock(string name)
+            {
+                Console.WriteLine("travis_fold:start:" + name);
+            }
+        }
+
+        class TeamCityLogger : IBlockLogger, Sake.Engine.Logging.ILog
+        {
+            private Sake.Engine.ISakeSettings _settings;
+
+            public TeamCityLogger(Sake.Engine.ISakeSettings settings)
+            {
+                _settings = settings;
+            }
+
+            public void Info(object value)
+            {
+                _settings.Output.WriteLine(value);
+            }
+
+            public void Warn(object value)
+            {
+                _settings.Output.WriteLine(Format(value, "WARNING"));
+            }
+
+            public void Error(object value)
+            {
+                _settings.Output.WriteLine(Format(value, "ERROR"));
+            }
+
+            public void Verbose(object value)
+            {
+                _settings.Output.WriteLine(value);
+            }
+
+            public static string Format(object v, string level)
+            {
+                if (v == null)
+                {
+                    return string.Empty;
+                }
+
+                var value = v.ToString();
+                if (value.StartsWith("##teamcity", StringComparison.Ordinal))
+                {
+                    return value;
+                }
+
+                value = value.Replace("|", "||")
+                            .Replace("'", "|'")
+                            .Replace("\r", "|r")
+                            .Replace("\n", "|n")
+                            .Replace("]", "|]");
+
+                return string.Format(System.Globalization.CultureInfo.InvariantCulture,
+                                    "##teamcity[message text='{0}' status='{1}']",
+                                    value,
+                                    level);
+            }
+
+            public void EndBlock(string name)
+            {
+                Console.WriteLine(string.Format("##teamcity[blockClosed name='{0}']", name));
+            }
+
+            public void StartBlock(string name)
+            {
+                Console.WriteLine(string.Format("##teamcity[blockOpened name='{0}']", name));
+            }
+        }
+
+        private string _lastBlockName;
+
+        public override void StartingTarget(string name)
+        {
+           base.StartingTarget(name);
+
+           var blockLogger = Log as IBlockLogger;
+           if (blockLogger != null)
+           {
+                if (_lastBlockName != null)
+                {
+                    blockLogger.EndBlock(_lastBlockName);
+                }
+                _lastBlockName = name;
+                blockLogger.StartBlock(name);
+           }
+           
+           Log.Info("Run target: " + name);
+        }
+  }
+
+@{
+  if (IsTeamCity)
+  {
+    Log = new TeamCityLogger(SakeSettings);
+    __WriteExecOutputToLogger = true;
+  }
+  if (IsTravisCi)
+  {
+    Log = new TravisCiLogger(SakeSettings);
+    __WriteExecOutputToLogger = true;
+  }
+}


### PR DESCRIPTION
Wraps targets in a travis logger fold. Makes log more readable. Collapses our very verbose logs on Travis into folds.

See https://travis-ci.org/aspnet/Microsoft.Data.Sqlite/builds/113208883 for example.
