### PR TITLE
Stop repeatedly adding .NET CLI to `$env:Path`

### DIFF
--- a/build/KoreBuild.ps1
+++ b/build/KoreBuild.ps1
@@ -27,15 +27,21 @@ $dotnetLocalInstallFolderBin = "$dotnetLocalInstallFolder\bin"
 if ($env:KOREBUILD_SKIP_RUNTIME_INSTALL -eq "1") 
 {
     Write-Host "Skipping runtime installation because KOREBUILD_SKIP_RUNTIME_INSTALL = 1"
+    if (!($env:Path.Split(';') -icontains $dotnetLocalInstallFolderBin))
+    {
+        # Add to the _end_ of the path in case preferred .NET CLI is not in the default location.
+        Write-Host "Adding $dotnetLocalInstallFolderBin to PATH"
+        $env:Path = "$env:PATH;$dotnetLocalInstallFolderBin"
+    }
 }
 else
 {
     & "$koreBuildFolder\dotnet\install.ps1" -Channel $dotnetChannel -Version $dotnetVersion
-}
-if (!($env:Path.Split(';') -icontains $dotnetLocalInstallFolderBin))
-{
-    Write-Host "Adding $dotnetLocalInstallFolderBin to PATH"
-    $env:Path = "$dotnetLocalInstallFolderBin;$env:PATH"
+    if (!($env:Path.Split(';') -icontains $dotnetLocalInstallFolderBin))
+    {
+        Write-Host "Adding $dotnetLocalInstallFolderBin to PATH"
+        $env:Path = "$dotnetLocalInstallFolderBin;$env:PATH"
+    }
 }
 
 if (!(Test-Path "$koreBuildFolder\Sake")) 

--- a/build/KoreBuild.ps1
+++ b/build/KoreBuild.ps1
@@ -21,16 +21,19 @@ if ($env:KOREBUILD_DOTNET_VERSION)
 {
     $dotnetVersion = $env:KOREBUILD_DOTNET_VERSION
 }
+
+$dotnetLocalInstallFolder = "$env:LOCALAPPDATA\Microsoft\dotnet\cli"
+$dotnetLocalInstallFolderBin = "$dotnetLocalInstallFolder\bin"
 if ($env:KOREBUILD_SKIP_RUNTIME_INSTALL -eq "1") 
 {
     Write-Host "Skipping runtime installation because KOREBUILD_SKIP_RUNTIME_INSTALL = 1"
 }
 else
 {
-    $dotnetLocalInstallFolder = "$env:LOCALAPPDATA\Microsoft\dotnet\cli"
-    $dotnetLocalInstallFolderBin = "$dotnetLocalInstallFolder\bin"
     & "$koreBuildFolder\dotnet\install.ps1" -Channel $dotnetChannel -Version $dotnetVersion
-
+}
+if (!($env:Path.Split(';') -icontains $dotnetLocalInstallFolderBin))
+{
     Write-Host "Adding $dotnetLocalInstallFolderBin to PATH"
     $env:Path = "$dotnetLocalInstallFolderBin;$env:PATH"
 }

--- a/build/KoreBuild.sh
+++ b/build/KoreBuild.sh
@@ -34,14 +34,20 @@ koreBuildFolder="${koreBuildFolder#/}"
 
 if [ ! -z "$KOREBUILD_SKIP_RUNTIME_INSTALL" ]; then
     echo "Skipping runtime installation because KOREBUILD_SKIP_RUNTIME_INSTALL is set"
+
+    # Add .NET installation directory to the path if it isn't yet included.
+    # Add to the _end_ in case preferred .NET CLI is not in the default location.
+    [[ ":$PATH:" != *":$DOTNET_INSTALL_DIR/bin:"* ]] && export PATH="$PATH:$DOTNET_INSTALL_DIR/bin"
 else
     # Need to set this variable because by default the install script
     # requires sudo
     export DOTNET_INSTALL_DIR=~/.dotnet
-    export PATH=$DOTNET_INSTALL_DIR/bin:$PATH
     export KOREBUILD_FOLDER="$(dirname $koreBuildFolder)"
     chmod +x $koreBuildFolder/dotnet/install.sh
     $koreBuildFolder/dotnet/install.sh --channel $KOREBUILD_DOTNET_CHANNEL --version $KOREBUILD_DOTNET_VERSION
+
+    # Add .NET installation directory to the path if it isn't yet included.
+    [[ ":$PATH:" != *":$DOTNET_INSTALL_DIR/bin:"* ]] && export PATH="$DOTNET_INSTALL_DIR/bin:$PATH"
 fi
 
 # Probe for Mono Reference assemblies


### PR DESCRIPTION
- environment changes in `KoreBuild.ps1` affect console when running `build.ps1`
  from a PowerShell prompt
- also add .NET CLI to the path even if `$env:KOREBUILD_SKIP_RUNTIME_INSTALL` is set
