### PR TITLE
Restore to koreBuildFolder

### DIFF
--- a/build/KoreBuild.sh
+++ b/build/KoreBuild.sh
@@ -70,7 +70,7 @@ fi
 sakeFolder=$koreBuildFolder/Sake
 if [ ! -d $sakeFolder ]; then
     toolsProject="$koreBuildFolder/project.json"
-    dotnet restore "$toolsProject" --packages "." -f https://www.myget.org/F/dnxtools/api/v3/index.json -v Minimal
+    dotnet restore "$toolsProject" --packages $koreBuildFolder -f https://www.myget.org/F/dnxtools/api/v3/index.json -v Minimal
     # Rename the project after restore because we don't want it to be restore afterwards
     mv "$toolsProject" "$toolsProject.norestore"
 fi


### PR DESCRIPTION
Not sure why using "." passes on @BrennanConroy's mac but fails on mine. Regardless, using an absolute path should resolve this.

Fix #46
