### PR TITLE
Don't ignore dotnet-test exit code if enviornment isn't set

### DIFF
--- a/build/shade/_dotnet-test.shade
+++ b/build/shade/_dotnet-test.shade
@@ -46,9 +46,10 @@ default test_options=' ${E("KOREBUILD_DOTNET_TEST_OPTIONS")}'
         }
         catch
         {
-            if (IgnoreDotnetTestExitCode)
+            if (!IgnoreDotnetTestExitCode)
             {
                 // Skip dotnet-test exit code.
+                throw;
             }
         }
     }


### PR DESCRIPTION
cc @divega
