### PR TITLE
Revert "Revert "Revert "Make NuGet packages serviceable"""

### DIFF
--- a/build/shade/_dotnet-pack.shade
+++ b/build/shade/_dotnet-pack.shade
@@ -21,7 +21,7 @@ default pack_options=' ${E("KOREBUILD_DOTNET_PACK_OPTIONS")}'
     var projectName=Path.GetFileName(projectFolder);
     var projectBin=Path.Combine(projectFolder, "bin");
 
-    var dotnetArgs=string.Format("pack{0} {1} --configuration {2} --serviceable", pack_options, projectFolder, configuration);
+    var dotnetArgs=string.Format("pack{0} {1} --configuration {2}", pack_options, projectFolder, configuration);
     Dotnet(dotnetArgs);
 
     CopyFolder(projectBin, Path.Combine(dotnetPackOutputDir, projectName), true);


### PR DESCRIPTION
@pranavkm 

Until nuget.exe 3.5.0-beta2 is available, let's instead set this option via KOREBUILD_DOTNET_PACK_OPTIONS on CI.
