### PR TITLE
MorkBuild: minor updates and fixes

### DIFF
--- a/scripts/KoreBuild.ps1
+++ b/scripts/KoreBuild.ps1
@@ -1,3 +1,4 @@
+#Requires -Version 4
 # Just here to isolate the build template from having to know anything about the interior structure of KoreBuild.
 # You can move pretty much everything else in this repo EXCEPT this file.
 $KoreBuildRoot = Convert-Path (Split-Path -Parent $PSScriptRoot)

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,3 +1,4 @@
+#Requires -Version 4
 # Installs KoreBuild into a repo, overwriting all previous build scripts
 # This script is downloaded and executed without any of the corresponding scripts in this repo, so don't assume anything in this repo is available!
 

--- a/src/Microsoft.AspNetCore.Build/ReplayNuGetLogger.cs
+++ b/src/Microsoft.AspNetCore.Build/ReplayNuGetLogger.cs
@@ -3,11 +3,9 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using NuGet.Common;
 
-namespace Microsoft.AspNetCore.Build.Tasks
+namespace Microsoft.AspNetCore.Build
 {
     public class ReplayNuGetLogger : ILogger
     {

--- a/src/Microsoft.AspNetCore.Build/Tasks/GatherProjectMetadata.cs
+++ b/src/Microsoft.AspNetCore.Build/Tasks/GatherProjectMetadata.cs
@@ -51,7 +51,7 @@ namespace Microsoft.AspNetCore.Build.Tasks
             // Paths and stuff (directories have trailing '\' to match MSBuild conventions)
             var dir = Path.GetDirectoryName(fullPath);
             project.SetMetadata("ProjectDir", dir + Path.DirectorySeparatorChar);
-            project.SetMetadata("Name", Path.GetFileName(dir));
+            project.SetMetadata("ProjectName", Path.GetFileName(dir));
             project.SetMetadata("SharedSourcesDir", Path.Combine(dir, "shared") + Path.DirectorySeparatorChar);
             project.SetMetadata("GeneratedBuildInfoFile", Path.Combine(dir, "BuildInfo.generated.cs"));
 

--- a/src/Microsoft.AspNetCore.Build/Tasks/NuGetInstall.cs
+++ b/src/Microsoft.AspNetCore.Build/Tasks/NuGetInstall.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.IO;
 using System.Threading;
 using Microsoft.Build.Framework;

--- a/src/Microsoft.AspNetCore.Build/scripts/KoreBuild.ps1
+++ b/src/Microsoft.AspNetCore.Build/scripts/KoreBuild.ps1
@@ -1,28 +1,9 @@
 Write-Host -ForegroundColor Green "Starting KoreBuild 2.0 ..."
 
-if($env:KOREBUILD_COMPATIBILITY -eq "1") {
-    # Rewrite arguments to handle compatibility with 1.0
-    $new_args = $args | ForEach-Object {
-        if($_ -eq "--quiet") {
-            "/v:m"
-        }
-        elseif($_.StartsWith("--")) {
-            # Other unknown switch
-            Write-Warning "Unknown KoreBuild 1.0 switch: $_. If this switch took an argument, you'll have a bad problem :)"
-        } else {
-            $target = [char]::ToUpper($_[0]) + $_.Substring(1)
-            "/t:$target"
-        }
-    }
-    Write-Host -ForegroundColor DarkGray "KoreBuild 1.0 Compatibility Mode Enabled"
-    Write-Host -ForegroundColor DarkGray "KoreBuild 1.0 Command Line: $args"
-    $args = $new_args
-    Write-Host -ForegroundColor DarkGray "KoreBuild 2.0 Command Line: $args"
-}
-
 $RepositoryRoot = Convert-Path (Get-Location)
 $BuildRoot = Join-Path $RepositoryRoot ".build"
 $KoreBuildRoot = (Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $PSScriptRoot)))
+$ArtifactsDir = Join-Path $RepositoryRoot "artifacts"
 
 $env:REPO_FOLDER = $RepositoryRoot
 $env:KOREBUILD_FOLDER = $KoreBuildRoot
@@ -40,13 +21,25 @@ if(Test-Path $KoreBuildLog) {
     del $KoreBuildLog
 }
 
+$MSBuildLog = Join-Path $BuildRoot "korebuild.msbuild.log"
+if(Test-Path $MSBuildLog) {
+    del $MSBuildLog
+}
+
+$MSBuildResponseFile = Join-Path $BuildRoot "korebuild.msbuild.rsp"
+if(Test-Path $MSBuildResponseFile) {
+    del $MSBuildResponseFile
+}
+
+
 function exec($cmd) {
     $cmdName = [IO.Path]::GetFileName($cmd)
     Write-Host -ForegroundColor DarkGray "> $cmdName $args"
     "`r`n>>>>> $cmd $args <<<<<`r`n" >> $KoreBuildLog
-    & $cmd @args >> $KoreBuildLog
-    if($LASTEXITCODE -ne 0) {
-        throw "Command returned exit code $($LASTEXITCODE): '$cmd $args'"
+    & $cmd @args 2>&1 >> $KoreBuildLog
+    $exitCode = $LASTEXITCODE
+    if($exitCode -ne 0) {
+        throw "'$cmdName $args' failed with exit code: $exitCode. See '$ArtifactsDir\korebuild.log' for details"
     }
 }
 
@@ -107,10 +100,13 @@ function EnsureMSBuild() {
             exec dotnet restore "$KoreBuildRoot\src\Microsoft.AspNetCore.Build" -v Detailed
             exec dotnet publish "$KoreBuildRoot\src\Microsoft.AspNetCore.Build" -o "$MSBuildDir\bin\pub" -f "netcoreapp1.0"
         } catch {
+            $ex = $error[0]
             # Clean up to ensure we aren't half-initialized
             if(Test-Path $MSBuildDir) {
                 del -rec -for $MSBuildDir
             }
+
+            throw $ex
         }
     } else {
         Write-Host -ForegroundColor DarkGray "MSBuild already initialized, use -Reset to refresh it"
@@ -133,23 +129,40 @@ function EnsureTools() {
     }
 }
 
-EnsureDotNet
-EnsureMSBuild
-EnsureTools
+try {
+    EnsureDotNet
+    EnsureMSBuild
+    EnsureTools
 
-$KoreBuildTargetsRoot = "$KoreBuildRoot\src\Microsoft.AspNetCore.Build\targets"
+    $KoreBuildTargetsRoot = "$KoreBuildRoot\src\Microsoft.AspNetCore.Build\targets"
 
-# Check for a local KoreBuild project
-$Proj = Join-Path "$RepositoryRoot" "makefile.proj"
-if(!(Test-Path $Proj)) {
-    $Proj = Join-Path "$KoreBuildTargetsRoot" "makefile.proj"
+    # Check for a local KoreBuild project
+    $Proj = Join-Path "$RepositoryRoot" "makefile.proj"
+    if(!(Test-Path $Proj)) {
+        $Proj = Join-Path "$KoreBuildTargetsRoot" "makefile.proj"
+    }
+
+    $MSBuildArguments = @"
+/nologo
+"$Proj"
+/p:KoreBuildToolsPackages="$ToolsDir"
+/p:KoreBuildTargetsPath="$KoreBuildTargetsRoot"
+/p:KoreBuildTasksPath="$MSBuildDir\bin\pub"
+/fl
+/flp:LogFile="$MSBuildLog";Verbosity=diagnostic;Encoding=UTF-8
+"@
+
+    $MSBuildArguments | Out-File -Encoding ASCII -FilePath $MSBuildResponseFile
+    $args | ForEach { $_ | Out-File -Append -Encoding ASCII -FilePath $MSBuildResponseFile } # Add local args to RSP
+
+    Write-Host -ForegroundColor Green "Starting build ..."
+    Write-Host -ForegroundColor DarkGray "> msbuild $Proj $args"
+
+    & "$MSBuildDir\bin\pub\CoreRun.exe" "$MSBuildDir\bin\pub\MSBuild.exe" `@"$MSBuildResponseFile"
+} finally {
+    # Copy logs to artifacts
+    if(!(Test-Path $ArtifactsDir)) {
+        mkdir $ArtifactsDir | Out-Null
+    }
+    cp -ErrorAction SilentlyContinue $MSBuildResponseFile,$KoreBuildLog,$MSBuildLog $ArtifactsDir
 }
-
-$MSBuildLog = Join-Path $BuildRoot "korebuild.msbuild.log"
-if(Test-Path $MSBuildLog) {
-    del $MSBuildLog
-}
-
-Write-Host -ForegroundColor Green "Starting build ..."
-Write-Host -ForegroundColor DarkGray "> msbuild $Proj $args"
-& "$MSBuildDir\bin\pub\CoreRun.exe" "$MSBuildDir\bin\pub\MSBuild.exe" /nologo $NoConsoleLoggerArg $CiLoggerArg "$Proj" /p:KoreBuildToolsPackages="$ToolsDir" /p:KoreBuildTargetsPath="$KoreBuildTargetsRoot" /p:KoreBuildTasksPath="$MSBuildDir\bin\pub" /fl "/flp:logFile=$MSBuildLog;verbosity=diagnostic" @args

--- a/src/Microsoft.AspNetCore.Build/targets/Clean.targets
+++ b/src/Microsoft.AspNetCore.Build/targets/Clean.targets
@@ -1,23 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-    <!-- Put targets attached to the 'Clean' phase of the Standard Lifecycle here. -->
+  <!-- Put targets attached to the 'Clean' phase of the Standard Lifecycle here. -->
 
-    <Target Name="CleanArtifactsDirectory" BeforeTargets="Clean">
-        <RemoveDir Directories="$(ArtifactsDir)" />
-    </Target>
+  <Target Name="CleanArtifactsDirectory" BeforeTargets="Clean">
+    <RemoveDir Directories="$(ArtifactsDir)" />
+  </Target>
 
-    <Target Name="CleanBinObjDirectories" BeforeTargets="Clean">
-        <ItemGroup>
-            <_ToClean Include="%(Projects.ProjectDir)bin" />
-            <_ToClean Include="%(Projects.ProjectDir)obj" />
-        </ItemGroup>
-        <RemoveDir Directories="@(_ToClean)" />
-    </Target>
+  <Target Name="CleanBinObjDirectories" BeforeTargets="Clean">
+    <ItemGroup>
+      <_ToClean Include="%(Projects.ProjectDir)bin" />
+      <_ToClean Include="%(Projects.ProjectDir)obj" />
+    </ItemGroup>
+    <RemoveDir Directories="@(_ToClean)" />
+  </Target>
 
-    <Target Name="CleanNpmModules" BeforeTargets="Clean">
-        <ItemGroup>
-            <_NpmToClean Include="%(NpmDirs.RootDir)%(NpmDirs.Directory)node_modules" />
-        </ItemGroup>
-        <RemoveDir Directories="@(_NpmToClean)" />
-    </Target>
+  <Target Name="CleanNpmModules" BeforeTargets="Clean">
+    <ItemGroup>
+      <_NpmToClean Include="%(NpmDirs.RootDir)%(NpmDirs.Directory)node_modules" />
+    </ItemGroup>
+    <RemoveDir Directories="@(_NpmToClean)" />
+  </Target>
 </Project>

--- a/src/Microsoft.AspNetCore.Build/targets/Compile.targets
+++ b/src/Microsoft.AspNetCore.Build/targets/Compile.targets
@@ -1,21 +1,29 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-    <!-- Put targets attached to the 'Compile' phase of the Standard Lifecycle here. -->
+  <!-- Put targets attached to the 'Compile' phase of the Standard Lifecycle here. -->
 
-    <Target Name="DotNetBuild" BeforeTargets="Compile">
-        <ItemGroup>
-            <_ToBuild Include="@(Projects)" Condition="'$(BuildSourceOnly)' != 'true' Or '%(Projects.ProjectGroup)' == 'src'" />
-        </ItemGroup>
+  <Target Name="DotNetBuild" BeforeTargets="Compile">
+    <ItemGroup>
+      <_ToBuild Include="@(Projects)" Condition="'$(BuildSourceOnly)' != 'true' Or '%(Projects.ProjectGroup)' == 'src'" />
+    </ItemGroup>
 
-        <Delete Files="%(_ToBuild.GeneratedBuildInfoFile)" Condition="Exists(%(_ToBuild.GeneratedBuildInfoFile))" />
-        <WriteLinesToFile
-            Lines="[assembly: System.Reflection.AssemblyMetadata(&quot;CommitHash&quot;, &quot;$(CommitHash)&quot;)]"
-            File="%(_ToBuild.GeneratedBuildInfoFile)"
-            Overwrite="true"
-            Condition="!Exists(%(_ToBuild.SharedSourcesDir)) And '$(CommitHash)' != ''" />
-        <Exec
-            Command="dotnet build --version-suffix &quot;$(BuildVersionSuffix)&quot; --configuration &quot;$(Configuration)&quot; $(DotNetBuild_Options) @(_ToBuild->'&quot;%(FullPath)&quot;', ' ')"
-            WorkingDirectory="$(RepositoryDir)" />
-        <Delete Files="%(_ToBuild.GeneratedBuildInfoFile)" Condition="Exists(%(_ToBuild.GeneratedBuildInfoFile))" />
-    </Target>
+    <Delete Files="%(_ToBuild.GeneratedBuildInfoFile)" Condition="Exists(%(_ToBuild.GeneratedBuildInfoFile))" />
+    <WriteLinesToFile
+      Lines="[assembly: System.Reflection.AssemblyMetadata(&quot;CommitHash&quot;, &quot;$(CommitHash)&quot;)]"
+      File="%(_ToBuild.GeneratedBuildInfoFile)"
+      Overwrite="true"
+      Condition="!Exists(%(_ToBuild.SharedSourcesDir)) And '$(CommitHash)' != ''" />
+    <Exec
+      Command="dotnet build --version-suffix &quot;$(BuildVersionSuffix)&quot; --configuration &quot;$(Configuration)&quot; $(DotNetBuild_Options) @(_ToBuild->'&quot;%(FullPath)&quot;', ' ')"
+      WorkingDirectory="$(RepositoryDir)" />
+    <Delete Files="%(_ToBuild.GeneratedBuildInfoFile)" Condition="Exists(%(_ToBuild.GeneratedBuildInfoFile))" />
+  </Target>
+  <Target Name="CopyBuildOutput" AfterTargets="DotNetBuild">
+    <ItemGroup>
+      <_ToCopy Include="%(Projects.ProjectDir)bin\**" Condition="'%(Projects.ProjectGroup)' == 'src'">
+        <ProjectName>%(Projects.ProjectName)</ProjectName>
+      </_ToCopy>
+    </ItemGroup>
+    <Copy SourceFiles="@(_ToCopy)" DestinationFiles="@(_ToCopy->'$(BuildDir)\%(ProjectName)\%(RecursiveDir)%(Filename)%(Extension)')" />
+  </Target>
 </Project>

--- a/src/Microsoft.AspNetCore.Build/targets/Package.targets
+++ b/src/Microsoft.AspNetCore.Build/targets/Package.targets
@@ -1,18 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-    <!-- Put targets attached to the 'Clean' phase of the Standard Lifecycle here. -->
+  <!-- Put targets attached to the 'Package' phase of the Standard Lifecycle here. -->
 
-    <Target Name="CleanPreviousPackOutput">
-        <RemoveDir Directories="$(PackagesDir)" />
-    </Target>
-    <Target Name="DotNetPack" DependsOnTargets="CleanPreviousPackOutput" BeforeTargets="Package">
-        <Exec
-            Command="dotnet pack --version-suffix &quot;$(BuildVersionSuffix)&quot; -o &quot;$(PackagesDir)&quot; --no-build --configuration &quot;$(Configuration)&quot; $(DotNetPack_Options) &quot;%(Projects.FullPath)&quot;"
-            Condition="'%(Projects.ProjectGroup)' == 'src'"
-            WorkingDirectory="$(RepositoryDir)" />
-      <ItemGroup>
-        <Packages Include="$(PackagesDir)/*.nupkg" Exclude="$(PackagesDir)/*.symbols.nupkg" />
-        <SymbolsPackages Include="$(PackagesDir)/*.symbols.nupkg" />
-      </ItemGroup>
-    </Target>
+  <Target Name="DotNetPack" BeforeTargets="Package">
+    <Exec
+      Command="dotnet pack --version-suffix &quot;$(BuildVersionSuffix)&quot; -o &quot;$(BuildDir)&quot; --no-build --configuration &quot;$(Configuration)&quot; $(DotNetPack_Options) &quot;%(Projects.FullPath)&quot;"
+      Condition="'%(Projects.ProjectGroup)' == 'src'"
+      WorkingDirectory="$(RepositoryDir)" />
+    <ItemGroup>
+      <Packages Include="$(BuildDir)/*.nupkg" Exclude="$(BuildDir)/*.symbols.nupkg" />
+      <SymbolsPackages Include="$(BuildDir)/*.symbols.nupkg" />
+    </ItemGroup>
+  </Target>
 </Project>

--- a/src/Microsoft.AspNetCore.Build/targets/Prepare.targets
+++ b/src/Microsoft.AspNetCore.Build/targets/Prepare.targets
@@ -1,42 +1,51 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-    <!-- Put targets attached to the 'Prepare' phase of the Standard Lifecycle here. -->
+  <!-- Put targets attached to the 'Prepare' phase of the Standard Lifecycle here. -->
 
-    <PropertyGroup>
-        <RestorePackagesTargets>
-            DotNetRestore;
-            NpmRestore;
-            BowerRestore;
-        </RestorePackagesTargets>
-    </PropertyGroup>
-    <Target Name="RestorePackages" DependsOnTargets="$(RestorePackagesTargets)" BeforeTargets="Prepare" />
+  <PropertyGroup>
+    <RestorePackagesTargets>
+      DotNetRestore;
+      NpmRestore;
+      BowerRestore;
+    </RestorePackagesTargets>
+  </PropertyGroup>
+  <Target Name="RestorePackages" DependsOnTargets="$(RestorePackagesTargets)" BeforeTargets="Prepare" />
 
-    <Target Name="RunGrunt" AfterTargets="RestorePackages" BeforeTargets="Prepare" Condition="'$(RunGrunt)' != 'skip' And '@(GruntDirs)' != ''">
-        <Exec
-            Command="grunt"
-            WorkingDirectory="%(GruntDirs.RootDir)%(GruntDirs.Directory)" />
-    </Target>
+  <Target Name="RunGrunt" AfterTargets="RestorePackages" BeforeTargets="Prepare" Condition="'$(RunGrunt)' != 'skip' And '@(GruntDirs)' != ''">
+    <Exec
+      Command="grunt"
+      WorkingDirectory="%(GruntDirs.RootDir)%(GruntDirs.Directory)" />
+  </Target>
 
-    <Target Name="DotNetRestore" Condition="'$(DotNetRestore)' != 'skip'">
-        <ItemGroup>
-            <RestoreDirectories Include="$(SourceDir)" Condition="Exists('$(SourceDir)')" />
-            <RestoreDirectories Include="$(TestDir)" Condition="Exists('$(TestDir)')" />
-            <RestoreDirectories Include="$(SamplesDir)" Condition="Exists('$(SamplesDir)')" />
-        </ItemGroup>
-        <Exec
-            Command="dotnet restore @(RestoreDirectories, ' ') $(DotNetRestore_Options)"
-            WorkingDirectory="$(RepositoryDir)" />
-    </Target>
+  <Target Name="DotNetRestore" Condition="'$(DotNetRestore)' != 'skip'">
+    <ItemGroup>
+      <RestoreDirectories Include="$(SourceDir)" Condition="Exists('$(SourceDir)')" />
+      <RestoreDirectories Include="$(TestDir)" Condition="Exists('$(TestDir)')" />
+      <RestoreDirectories Include="$(SamplesDir)" Condition="Exists('$(SamplesDir)')" />
+    </ItemGroup>
+    <Exec
+        Command="dotnet restore @(RestoreDirectories, ' ') $(DotNetRestore_Options)"
+        WorkingDirectory="$(RepositoryDir)" />
+  </Target>
 
-    <Target Name="NpmRestore" Condition="'$(NpmRestore)' != 'skip' And '@(NpmDirs)' != ''">
-        <Exec
-            Command="npm install $(NpmRestore_Options)"
-            WorkingDirectory="%(NpmDirs.RootDir)%(NpmDirs.Directory)" />
-    </Target>
+  <Target Name="NpmRestore" Condition="'$(NpmRestore)' != 'skip' And '@(NpmDirs)' != ''">
+    <Exec
+      Command="npm install $(NpmRestore_Options)"
+      WorkingDirectory="%(NpmDirs.RootDir)%(NpmDirs.Directory)" />
+  </Target>
 
-    <Target Name="BowerRestore" Condition="'$(BowerRestore)' != 'skip' And '@(BowerDirs)' != ''">
-        <Exec
-            Command="bower install $(BowerRestore_Options)"
-            WorkingDirectory="%(BowerDirs.RootDir)%(BowerDirs.Directory)" />
-    </Target>
+  <Target Name="BowerRestore" Condition="'$(BowerRestore)' != 'skip' And '@(BowerDirs)' != ''">
+    <Exec
+      Command="bower install $(BowerRestore_Options)"
+      WorkingDirectory="%(BowerDirs.RootDir)%(BowerDirs.Directory)" />
+  </Target>
+
+  <!--
+    Doesn't this belong in Clean? No, because Clean is about cleaning the repo, including all incremental build outputs
+    This is just cleaning the artifacts dir, which can be reconstituted from the incremental outputs, so we're OK with cleaning
+    it on every build, and it makes sure that if a project's build outputs shrink from build-to-build, we get the right outputs
+  -->
+  <Target Name="CleanPreviousBuildOutput" BeforeTargets="Prepare">
+    <RemoveDir Directories="$(BuildDir)" />
+  </Target>
 </Project>

--- a/src/Microsoft.AspNetCore.Build/targets/ProductInfo.props
+++ b/src/Microsoft.AspNetCore.Build/targets/ProductInfo.props
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-    <PropertyGroup>
-        <!-- Product-specific properties -->
-        <DefaultAuthors>Microsoft Open Technologies, Inc.</DefaultAuthors>
-        <ProductStartDate>2015-01-01</ProductStartDate>
-        <BuildQuality>alpha</BuildQuality>
-        <BuildVersion>1.0.1</BuildVersion>
-    </PropertyGroup>
+  <PropertyGroup>
+    <!-- Product-specific properties -->
+    <DefaultAuthors>Microsoft</DefaultAuthors>
+    <ProductStartDate>2015-01-01</ProductStartDate>
+    <BuildQuality>alpha</BuildQuality>
+    <BuildVersion>1.0.1</BuildVersion>
+  </PropertyGroup>
 </Project>

--- a/src/Microsoft.AspNetCore.Build/targets/StandardBuild.targets
+++ b/src/Microsoft.AspNetCore.Build/targets/StandardBuild.targets
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-    <!-- Defines the ASP.NET Core Standard Build (a standard pattern for building the ASP.NET Core Repositories) -->
+  <!-- Defines the ASP.NET Core Standard Build (a standard pattern for building the ASP.NET Core Repositories) -->
 
-    <Import Project="$(KoreBuildTasksPath)/Microsoft.AspNetCore.Build.tasks" />
+  <Import Project="$(KoreBuildTasksPath)/Microsoft.AspNetCore.Build.tasks" />
 
-    <!-- The order of this technically doesn't matter but it's nice to keep them in the order they'll run :) -->
-    <Import Project="$(MSBuildThisFileDirectory)/Clean.targets" />
-    <Import Project="$(MSBuildThisFileDirectory)/Initialize.targets" />
-    <Import Project="$(MSBuildThisFileDirectory)/Prepare.targets" />
-    <Import Project="$(MSBuildThisFileDirectory)/Compile.targets" />
-    <Import Project="$(MSBuildThisFileDirectory)/Test.targets" />
-    <Import Project="$(MSBuildThisFileDirectory)/Package.targets" />
-    <Import Project="$(MSBuildThisFileDirectory)/Verify.targets" />
-    <Import Project="$(MSBuildThisFileDirectory)/Publish.targets" />
+  <!-- The order of this technically doesn't matter but it's nice to keep them in the order they'll run :) -->
+  <Import Project="$(MSBuildThisFileDirectory)/Clean.targets" />
+  <Import Project="$(MSBuildThisFileDirectory)/Initialize.targets" />
+  <Import Project="$(MSBuildThisFileDirectory)/Prepare.targets" />
+  <Import Project="$(MSBuildThisFileDirectory)/Compile.targets" />
+  <Import Project="$(MSBuildThisFileDirectory)/Test.targets" />
+  <Import Project="$(MSBuildThisFileDirectory)/Package.targets" />
+  <Import Project="$(MSBuildThisFileDirectory)/Verify.targets" />
+  <Import Project="$(MSBuildThisFileDirectory)/Publish.targets" />
 </Project>

--- a/src/Microsoft.AspNetCore.Build/targets/StandardLifecycle.targets
+++ b/src/Microsoft.AspNetCore.Build/targets/StandardLifecycle.targets
@@ -52,4 +52,8 @@
   <Target Name="Clean" DependsOnTargets="Initialize">
     <Message Text="*** Completed Clean Phase ***" />
   </Target>
+
+  <!-- Targets used by CI/etc. Here so that they can be reconfigured via KoreBuild rather than messing with build scripts -->
+  <!-- The target invoked by Universe-Coherence when this repo is built -->
+  <Target Name="UniverseCoherenceBuild" DependsOnTargets="Verify" />
 </Project>

--- a/src/Microsoft.AspNetCore.Build/targets/Test.targets
+++ b/src/Microsoft.AspNetCore.Build/targets/Test.targets
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-    <!-- Put targets attached to the 'Test' phase of the Standard Lifecycle here. -->
+  <!-- Put targets attached to the 'Test' phase of the Standard Lifecycle here. -->
 
-    <Target Name="DotNetTest" BeforeTargets="Test">
-        <ItemGroup>
-            <_ToTest Include="@(TestProjects)" Condition="'$(BuildPlatformName)' == 'Windows' Or '%(TFM_netcoreapp1_0)' == 'true'" />
-        </ItemGroup>
-        <PropertyGroup>
-            <DotNetTestFrameworkArg Condition="'$(BuildPlatformName)' != 'Windows'">-f netcoreapp1.0</DotNetTestFrameworkArg>
-        </PropertyGroup>
-        <Exec
-            Command="dotnet test --configuration &quot;$(Configuration)&quot; --no-build &quot;%(_ToTest.FullPath)&quot; $(DotNetTestFrameworkArg)"
-            WorkingDirectory="%(_ToTest.ProjectDir)" />
-    </Target>
+  <Target Name="DotNetTest" BeforeTargets="Test">
+    <ItemGroup>
+      <_ToTest Include="@(TestProjects)" Condition="'$(BuildPlatformName)' == 'Windows' Or '%(TFM_netcoreapp1_0)' == 'true'" />
+    </ItemGroup>
+    <PropertyGroup>
+      <DotNetTestFrameworkArg Condition="'$(BuildPlatformName)' != 'Windows'">-f netcoreapp1.0</DotNetTestFrameworkArg>
+    </PropertyGroup>
+    <Exec
+      Command="dotnet test --configuration &quot;$(Configuration)&quot; --no-build &quot;%(_ToTest.FullPath)&quot; $(DotNetTestFrameworkArg)"
+      WorkingDirectory="%(_ToTest.ProjectDir)" />
+  </Target>
 </Project>

--- a/src/Microsoft.AspNetCore.Build/targets/makefile.proj
+++ b/src/Microsoft.AspNetCore.Build/targets/makefile.proj
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" InitialTargets="Initialize" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-    <Import Project="$(MSBuildThisFileDirectory)\ProductInfo.props" />
-    <Import Project="$(MSBuildThisFileDirectory)\StandardLifecycle.targets" />
-    <Import Project="$(MSBuildThisFileDirectory)\StandardBuild.targets" />
+  <Import Project="$(MSBuildThisFileDirectory)\ProductInfo.props" />
+  <Import Project="$(MSBuildThisFileDirectory)\StandardLifecycle.targets" />
+  <Import Project="$(MSBuildThisFileDirectory)\StandardBuild.targets" />
 </Project>

--- a/template2/build.ps1
+++ b/template2/build.ps1
@@ -1,3 +1,5 @@
+#Requires -Version 4
+# Don't remove the next line, it's used by Universe to detect a KoreBuild 2.0-based repo.
 # KoreBuild 2.0
 
 <#


### PR DESCRIPTION
- Whitespace cleanup (XML indent -> 2 to match VS defaults)
- Namespace resync (NuGetReplayLogger got accidentally dragged into the Tasks namespace, but it isn't a task)
- Fix hidden messages on Unix (due to using ANSI code for Black, which yields black-on-black in most terminals ;))
- Copy MSBuild/KoreBuild logs to artifacts after build (can't do it in the build because it locks `artifacts` which means we can't really clean it)
- Update `artifacts` final layout to match KoreBuild
- Apparently @victorhurdugaci says we're calling this new MSBuild-based KoreBuild "MorkBuild" and well... 

![http://i2.kym-cdn.com/photos/images/newsfeed/000/284/922/0e3.png](http://i2.kym-cdn.com/photos/images/newsfeed/000/284/922/0e3.png)

**ALSO**: Removed KOREBUILD_COMPATIBILITY. Turns out Universe will need to call different targets anyway, which means it needs to "detect" KoreBuild2 already :(. May as well just remove the compat stuff now then.

/cc @pranavkm @victorhurdugaci
