### PR TITLE
Use ** rather than * for globbing

### DIFF
--- a/build/shade/_k-standard-goals.shade
+++ b/build/shade/_k-standard-goals.shade
@@ -16,9 +16,9 @@ default BUILD_DIR='${Path.Combine(TARGET_DIR, "build")}'
 default TEST_DIR='${Path.Combine(TARGET_DIR, "test")}'
 default Configuration='${E("Configuration")}'
 default PACKAGELIST_JSON_FILENAME = 'NuGetPackageVerifier.json'
-default SRC_PROJECT_GLOB = "src/*/project.json"
-default TEST_PROJECT_GLOB = "test/*/project.json"
-default SAMPLES_PROJECT_GLOB = "samples/*/project.json"
+default SRC_PROJECT_GLOB = "src/**/project.json"
+default TEST_PROJECT_GLOB = "test/**/project.json"
+default SAMPLES_PROJECT_GLOB = "samples/**/project.json"
 
 @{
   if (string.IsNullOrEmpty(E("DOTNET_BUILD_VERSION")))
@@ -103,7 +103,7 @@ default SAMPLES_PROJECT_GLOB = "samples/*/project.json"
     }
 
 #build-clean if='Directory.Exists("src")'
-  k-clean each='var projectFile in Files.Include("src/*/project.json")'
+  k-clean each='var projectFile in Files.Include(SRC_PROJECT_GLOB)'
 
 #ci-deep-clean .deep-clean target='clean' if='IsTeamCity'
 


### PR DESCRIPTION
I ran into an issue when building https://github.com/aspnet/JavaScriptServices where the samples were in a lower subdirectory.  Since the glob `samples/*/project.json` would only match projects directly below `samples`, the projects were not being built. Using `**` instead matches all `project.json` in all subdirectories.
