### PR TITLE
Run NPM installs in series, not parallel

### DIFF
--- a/build/shade/_k-standard-goals.shade
+++ b/build/shade/_k-standard-goals.shade
@@ -57,7 +57,10 @@ default SAMPLES_PROJECT_GLOB = "samples/*/project.json"
     // Find all dirs that contain a package.json file
     var npmDirs = GetDirectoriesContaining(Directory.GetCurrentDirectory(), "package.json").ToArray();
     var npmOptions = E("KOREBUILD_NPM_INSTALL_OPTIONS") ?? "--quiet --depth 0";
-    Parallel.ForEach(npmDirs, npmDir => Npm("install " + npmOptions, npmDir));
+    foreach (var npmDir in npmDirs)
+    {
+        Npm("install " + npmOptions, npmDir);
+    }
   }
 
 #restore-bower-components


### PR DESCRIPTION
I'm seeing intermittent build failures on the JavaScriptServices repo when it builds on Windows. Since there have been many reports of NPM instability when run in parallel on Windows, this change makes NPM installs run in series. Obviously it will take longer, but hopefully it will produce more consistent results. We won't know whether this actually fixes the issue until this runs in CI.
