### PR TITLE
Ensure build number is the same across the solution build

### DIFF
--- a/build/common.props
+++ b/build/common.props
@@ -20,7 +20,9 @@
         <!-- for aspnet CI -->
         <BuildNumber Condition="'$(BuildNumber)'==''">$(KOREBUILD_BUILD_NUMBER)</BuildNumber>
 
+        <!-- fallback build number if not set by KoreBuild-->
         <BuildNumber Condition="'$(BuildNumber)'==''">$(_SecondBasedTimeStamp)</BuildNumber>
+
         <VersionSuffix Condition="'$(VersionSuffix)'!='' AND '$(BuildNumber)' != ''">$(VersionSuffix)-$(BuildNumber)</VersionSuffix>
         <VersionSuffix Condition="'$(VersionSuffix)'==''">$(BuildNumber)</VersionSuffix>
 

--- a/build/shade/_k-standard-goals.shade
+++ b/build/shade/_k-standard-goals.shade
@@ -21,13 +21,9 @@ default TEST_PROJECT_GLOB = "test/*/*.csproj"
 default SAMPLES_PROJECT_GLOB = "samples/*/*.csproj"
 
 @{
-  if (string.IsNullOrEmpty(E("DOTNET_BUILD_VERSION")))
+  if (string.IsNullOrEmpty(E("BuildNumber")))
   {
-    E("DOTNET_BUILD_VERSION", BuildNumber);
-  }
-  if (string.IsNullOrEmpty(E("DOTNET_ASSEMBLY_FILE_VERSION")))
-  {
-    E("DOTNET_ASSEMBLY_FILE_VERSION", CreateDayBasedVersionNumber());
+    E("BuildNumber", BuildNumber);
   }
   if (string.IsNullOrEmpty(Configuration))
   {


### PR DESCRIPTION
Fixes the issue of build numbers being different per project on the same build run.