### PR TITLE
Always install the SDK specified in KoreBuild

### DIFF
--- a/build/KoreBuild.ps1
+++ b/build/KoreBuild.ps1
@@ -16,15 +16,6 @@ $dotnetVersionFile = $koreBuildFolder + "\cli.version"
 $dotnetChannel = "rel-1.0.0"
 $dotnetVersion = Get-Content $dotnetVersionFile
 
-if ($env:KOREBUILD_DOTNET_CHANNEL)
-{
-    $dotnetChannel = $env:KOREBUILD_DOTNET_CHANNEL
-}
-if ($env:KOREBUILD_DOTNET_VERSION)
-{
-    $dotnetVersion = $env:KOREBUILD_DOTNET_VERSION
-}
-
 $dotnetLocalInstallFolder = $env:DOTNET_INSTALL_DIR
 if (!$dotnetLocalInstallFolder)
 {
@@ -52,6 +43,16 @@ else
 {
     # Install the version of dotnet-cli used to compile
     & "$koreBuildFolder\dotnet\dotnet-install.ps1" -Channel $dotnetChannel -Version $dotnetVersion -Architecture x64
+    if ($env:KOREBUILD_DOTNET_VERSION)
+    {
+        if ($env:KOREBUILD_DOTNET_CHANNEL)
+        {
+            $dotnetChannel = $env:KOREBUILD_DOTNET_CHANNEL
+        }
+
+        & "$koreBuildFolder\dotnet\dotnet-install.ps1" -Channel $dotnetChannel -Version $dotnetVersion -Architecture x64
+    }
+
     InstallSharedRuntime '1.1.0' 'release/1.1.0'
     if ($env:KOREBUILD_DOTNET_SHARED_RUNTIME_VERSION)
     {

--- a/build/KoreBuild.sh
+++ b/build/KoreBuild.sh
@@ -31,10 +31,8 @@ koreBuildFolder="${scriptRoot/$repoFolder/}"
 koreBuildFolder="${koreBuildFolder#/}"
 
 versionFile="$koreBuildFolder/cli.version"
-version=$(<$versionFile)
-
-[ -z "$KOREBUILD_DOTNET_CHANNEL" ] && KOREBUILD_DOTNET_CHANNEL=rel-1.0.0
-[ -z "$KOREBUILD_DOTNET_VERSION" ] && KOREBUILD_DOTNET_VERSION=$version
+dotnetVersion=$(<$versionFile)
+dotnetChannel="rel-1.0.0"
 
 install_shared_runtime() {
     eval $invocation
@@ -61,6 +59,13 @@ else
     export DOTNET_INSTALL_DIR=$DOTNET_INSTALL_DIR
     export KOREBUILD_FOLDER="$(dirname $koreBuildFolder)"
     chmod +x $koreBuildFolder/dotnet/dotnet-install.sh
+
+    $koreBuildFolder/dotnet/dotnet-install.sh --channel $dotnetChannel --version $dotnetVersion
+    if [ ! -z "$KOREBUILD_DOTNET_VERSION" ]; then
+        dotnetVersion="$KOREBUILD_DOTNET_VERSION"
+        [ ! -z "$KOREBUILD_DOTNET_CHANNEL" ] && dotnetChannel="$KOREBUILD_DOTNET_CHANNEL"
+        $koreBuildFolder/dotnet/dotnet-install.sh --channel $dotnetChannel --version $dotnetVersion
+    fi
 
     # Install the version of dotnet-cli used to compile
     $koreBuildFolder/dotnet/dotnet-install.sh --channel $KOREBUILD_DOTNET_CHANNEL --version $KOREBUILD_DOTNET_VERSION


### PR DESCRIPTION
We will rely on the global.json to pick up the right version of the CLI.