### PR TITLE
Print link to shared runtime installer

### DIFF
--- a/build/KoreBuild.ps1
+++ b/build/KoreBuild.ps1
@@ -17,11 +17,11 @@ $dotnetChannel = "preview"
 $dotnetVersion = Get-Content $dotnetVersionFile
 $sharedRuntimeVersion = Get-Content (Join-Path $koreBuildFolder 'shared-runtime.version')
 
-if ($env:KOREBUILD_DOTNET_CHANNEL) 
+if ($env:KOREBUILD_DOTNET_CHANNEL)
 {
     $dotnetChannel = $env:KOREBUILD_DOTNET_CHANNEL
 }
-if ($env:KOREBUILD_DOTNET_VERSION) 
+if ($env:KOREBUILD_DOTNET_VERSION)
 {
     $dotnetVersion = $env:KOREBUILD_DOTNET_VERSION
 }
@@ -41,9 +41,9 @@ function InstallSharedRuntime([string] $version, [string] $channel)
         & "$koreBuildFolder\dotnet\dotnet-install.ps1" -Channel $channel -SharedRuntime -Version $version -Architecture x64
     }
 }
- 
+
 $newPath = "$dotnetLocalInstallFolder;$env:PATH"
-if ($env:KOREBUILD_SKIP_RUNTIME_INSTALL -eq "1") 
+if ($env:KOREBUILD_SKIP_RUNTIME_INSTALL -eq "1")
 {
     Write-Host "Skipping runtime installation because KOREBUILD_SKIP_RUNTIME_INSTALL = 1"
     # Add to the _end_ of the path in case preferred .NET CLI is not in the default location.
@@ -53,7 +53,15 @@ else
 {
     & "$koreBuildFolder\dotnet\dotnet-install.ps1" -Channel $dotnetChannel -Version $dotnetVersion -Architecture x64
     InstallSharedRuntime '1.0.0' 'preview'
-    InstallSharedRuntime $sharedRuntimeVersion 'master'
+
+    $sharedRuntimeChannel='master'
+    InstallSharedRuntime $sharedRuntimeVersion $sharedRuntimeChannel
+
+    Write-Host ''
+    Write-Host -ForegroundColor Cyan 'To run tests in Visual Studio, you may need to run this installer:'
+    Write-Host -ForegroundColor Cyan "https://dotnetcli.blob.core.windows.net/dotnet/$sharedRuntimeChannel/Installers/$sharedRuntimeVersion/dotnet-win-x64.$sharedRuntimeVersion.exe"
+    Write-Host ''
+
     if ($env:KOREBUILD_DOTNET_SHARED_RUNTIME_VERSION)
     {
         $channel = 'master'
@@ -74,14 +82,14 @@ if (!($env:Path.Split(';') -icontains $dotnetLocalInstallFolder))
 $sharedPath = (Join-Path (Split-Path ((get-command dotnet.exe).Path) -Parent) "shared");
 (Get-ChildItem $sharedPath -Recurse *dotnet.exe) | %{ $_.FullName } | Remove-Item;
 
-if (!(Test-Path "$koreBuildFolder\Sake")) 
+if (!(Test-Path "$koreBuildFolder\Sake"))
 {
     $toolsProject = "$koreBuildFolder\project.json"
     if (!(Test-Path $toolsProject))
     {
         if (Test-Path "$toolsProject.norestore")
         {
-            mv "$toolsProject.norestore" "$toolsProject" 
+            mv "$toolsProject.norestore" "$toolsProject"
         }
         else
         {
@@ -103,7 +111,7 @@ if (!(Test-Path "$koreBuildFolder\Sake"))
 }
 
 $makeFilePath = "makefile.shade"
-if (!(Test-Path $makeFilePath)) 
+if (!(Test-Path $makeFilePath))
 {
     $makeFilePath = "$koreBuildFolder\shade\makefile.shade"
 }


### PR DESCRIPTION
VS 2017 doesn't, by default, use the same sharedfx that korebuild will install. This change prints a link to the downloader required to make VS test work on 2017 projects.