### PR TITLE
Remove usage of -parallel flag on dotnet-test

### DIFF
--- a/build/shade/_dotnet-test.shade
+++ b/build/shade/_dotnet-test.shade
@@ -22,15 +22,7 @@ default framework = ''
 @{
     var projectFolder = Path.GetDirectoryName(projectFile);
     var projectName = Path.GetFileName(projectFolder);
-
-    var noParallelTestProjects = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-    if (!string.IsNullOrEmpty(NO_PARALLEL_TEST_PROJECTS))
-    {
-        noParallelTestProjects.UnionWith(NO_PARALLEL_TEST_PROJECTS.Split((char)','));
-    }
-
     var testArgs = test_options + " --configuration " + configuration;
-    testArgs += noParallelTestProjects.Contains(projectName) ? " -parallel none" : "";
 
     if (!string.IsNullOrEmpty(framework))
     {


### PR DESCRIPTION
dotnet-test no longer supports -parallel. Any tests that require non-parallel test runs should configure this via code instead.

Example:
```c#
[assembly: CollectionBehavior(DisableTestParallelization = true)]
```
cref https://xunit.github.io/docs/running-tests-in-parallel.html
cref https://xunit.github.io/docs/configuring-with-xml

cc @bricelam (EF Core SQL Server tests)
cc @pranavkm we should be able to remove this from aspnetci config 
