### PR TITLE
Do not assume content of the SAMPLES_PROJECT_GLOB variable

### DIFF
--- a/build/shade/_k-standard-goals.shade
+++ b/build/shade/_k-standard-goals.shade
@@ -154,13 +154,15 @@ default SAMPLES_PROJECT_GLOB = "samples/*/*.csproj"
 
       projectGlobs.AddRange(srcProjects);
     }
+
     if (!BuildSrcOnly && Directory.Exists("test"))
     {
-        projectGlobs.AddRange(Files.Include(TEST_PROJECT_GLOB).ToList());
+      projectGlobs.AddRange(Files.Include(TEST_PROJECT_GLOB).ToList());
     }
-    if (!BuildSrcOnly && Directory.Exists("samples") && Directory.EnumerateFiles("samples", "*.csproj", SearchOption.AllDirectories).Any())
+
+    if (!BuildSrcOnly && Directory.Exists("samples"))
     {
-        projectGlobs.AddRange(Files.Include(SAMPLES_PROJECT_GLOB).ToList());
+      projectGlobs.AddRange(Files.Include(SAMPLES_PROJECT_GLOB).ToList());
     }
 
     if (projectGlobs.Any())


### PR DESCRIPTION
- samples folder may exist _only_ to enable use of a modified SAMPLES_PROJECT_GLOB

Other alternatives to the `Directory.Exists("samples")` approach:
- change default glob to something like `sam*ples/*/*.csproj`
  - that wouldn't require the samples folder but may in the future match something unintended
- update PathResolver.shade in Sake to avoid `Directory.GetFiles(path, ...)` when path doesn't exist
  - could copy PathResolver.shade into KoreBuild to avoid updating Sake
  - but, this option can still hide real errors very easily