### PR TITLE
Disable console colors when running on a CI machine

### DIFF
--- a/build/KoreBuild.ps1
+++ b/build/KoreBuild.ps1
@@ -89,7 +89,7 @@ $msbuildArtifactsDir = "$repoFolder/artifacts/msbuild"
 $msbuildLogFilePath = "$msbuildArtifactsDir/msbuild.log"
 $msBuildResponseFile = "$msbuildArtifactsDir/msbuild.rsp"
 
-$preflightClpOption='/clp=DisableConsoleColor'
+$preflightClpOption='/clp:DisableConsoleColor'
 $msbuildClpOption='/clp:DisableConsoleColor;Summary'
 if [ -z "${env:CI}${env:APPVEYOR}${env:TEAMCITY_VERSION}${env:TRAVIS}" ]; then
     # Not on any of the CI machines. Fine to use colors.

--- a/build/KoreBuild.sh
+++ b/build/KoreBuild.sh
@@ -127,12 +127,21 @@ if [ ! -f $msbuildArtifactsDir ]; then
     mkdir -p $msbuildArtifactsDir
 fi
 
+preflightClpOption='/clp=DisableConsoleColor'
+msbuildClpOption='/clp:DisableConsoleColor;Summary'
+if [ -z "${CI}${APPVEYOR}${TEAMCITY_VERSION}${TRAVIS}" ]; then
+    # Not on any of the CI machines. Fine to use colors.
+    preflightClpOption=''
+    msbuildClpOption='/clp:Summary'
+fi
+
 cat > $msbuildPreflightResponseFile <<ENDMSBUILDPREFLIGHT
 /nologo
 /p:NetFxVersion=$netfxversion
 /p:PreflightRestore=true
 /p:RepositoryRoot="$repoFolder/"
 /t:Restore
+$preflightClpOption
 "$makeFileProj"
 ENDMSBUILDPREFLIGHT
 
@@ -144,7 +153,7 @@ cat > $msbuildResponseFile <<ENDMSBUILDARGS
 /p:RepositoryRoot="$repoFolder/"
 /fl
 /flp:LogFile="$msbuildLogFile";Verbosity=detailed;Encoding=UTF-8
-/clp:Summary
+$msbuildClpOption
 "$makeFileProj"
 ENDMSBUILDARGS
 echo -e "$msbuild_args" >> $msbuildResponseFile

--- a/build/KoreBuild.sh
+++ b/build/KoreBuild.sh
@@ -127,7 +127,7 @@ if [ ! -f $msbuildArtifactsDir ]; then
     mkdir -p $msbuildArtifactsDir
 fi
 
-preflightClpOption='/clp=DisableConsoleColor'
+preflightClpOption='/clp:DisableConsoleColor'
 msbuildClpOption='/clp:DisableConsoleColor;Summary'
 if [ -z "${CI}${APPVEYOR}${TEAMCITY_VERSION}${TRAVIS}" ]; then
     # Not on any of the CI machines. Fine to use colors.


### PR DESCRIPTION
- a few of our builds fail on Travis due to these excess characters
  - e.g https://travis-ci.org/aspnet/Mvc/builds/207068889
- barely useful anywhere, even Travis (where web page shows some color)

nits (both for KoreBuild.ps1 only):
- quote the `$makeFileProj` variable in the preflight command too
- move project file to the end of the response file