### PR TITLE
Work around Microsoft/msbuild#1792

### DIFF
--- a/build/KoreBuild.sh
+++ b/build/KoreBuild.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -o pipefail
 
 # Colors
 GREEN="\033[1;32m"

--- a/build/KoreBuild.sh
+++ b/build/KoreBuild.sh
@@ -6,6 +6,7 @@ CYAN="\033[0;36m"
 RESET="\033[0m"
 RED="\033[0;31m"
 
+
 # functions
 
 __exec() {
@@ -14,7 +15,13 @@ __exec() {
 
     local cmdname=$(basename $cmd)
     echo -e "${CYAN}> $cmdname $@${RESET}"
-    $cmd "$@"
+
+    if [ -z "${TRAVIS}" ]; then
+        $cmd "$@"
+    else
+        # Work around https://github.com/Microsoft/msbuild/issues/1792
+        $cmd "$@" | tee /dev/null
+    fi
 
     local exitCode=$?
     if [ $exitCode -ne 0 ]; then


### PR DESCRIPTION
- piping MsBuild output into `tee` cleans up the excess ANSI character codes

Extend the related `/clp:DisableConsoleColor` fix in fc6f034 to Windows CI machines.