### PR TITLE
Generate global.json file in repo folder

### DIFF
--- a/build/KoreBuild.ps1
+++ b/build/KoreBuild.ps1
@@ -126,5 +126,7 @@ if (!(Test-Path $msbuildArtifactsDir))
 
 $msBuildArguments | Out-File -Encoding ASCII -FilePath $msBuildResponseFile
 
+# workaround https://github.com/dotnet/core-setup/issues/1664
+@{ sdk = @{ version = $dotnetVersion } } | ConvertTo-Json -Compress | Out-File "$repoFolder/global.json" -Encoding ascii
 exec dotnet msbuild /nologo $preflightClpOption /t:Restore /p:PreflightRestore=true "$makeFileProj"
 exec dotnet msbuild `@"$msBuildResponseFile"

--- a/build/KoreBuild.sh
+++ b/build/KoreBuild.sh
@@ -160,6 +160,9 @@ $preflightClpOption
 "$makeFileProj"
 ENDMSBUILDPREFLIGHT
 
+# workaround https://github.com/dotnet/core-setup/issues/1664
+echo "{\"sdk\":{\"version\":\"$KOREBUILD_DOTNET_VERSION\"}}" > "$repoFolder/global.json"
+
 __exec dotnet msbuild @"$msbuildPreflightResponseFile"
 
 cat > $msbuildResponseFile <<ENDMSBUILDARGS


### PR DESCRIPTION
Global.json is required to use the 2.0.0 preview CLI when the 1.0.0 CLI is already installed.

Workaround https://github.com/dotnet/core-setup/issues/1664