### PR TITLE
Use uncached azure feed on Travis OSX agents

### DIFF
--- a/build/KoreBuild.sh
+++ b/build/KoreBuild.sh
@@ -57,6 +57,27 @@ cd $repoFolder
 
 scriptRoot="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
+# The default azure feed used to download .NET Core CLI
+dotnet_azure_feed="https://dotnetcli.azureedge.net/dotnet"
+
+if [ "$(uname)" == "Darwin" ]; then
+    ulimit -n 2048
+
+    # Check that OS is 10.12 or newer
+    osx_version="$(sw_vers | grep ProductVersion | awk '{print $2}')"
+    minor_version="$(echo $osx_version | awk -F '.' '{print $2}')"
+    if [ $minor_version -lt 12 ]; then
+        echo -e "${RED}.NET Core 2.0 requires OSX 10.12 or newer. Current version is $osx_version.${RESET}"
+        exit 1
+    fi
+
+    if [ "$TRAVIS" = true ]; then
+        # Travis OSX agents consistently have networking issues pulling from dotnetcli.azureedge.net.
+        # This switches to using the "uncached feed"
+        dotnet_azure_feed="https://dotnetcli.blob.core.windows.net/dotnet"
+    fi
+fi
+
 versionFile="$scriptRoot/cli.version"
 version=$(<$versionFile)
 sharedRuntimeVersionFile="$scriptRoot/shared-runtime.version"
@@ -73,7 +94,15 @@ install_shared_runtime() {
 
     local sharedRuntimePath="$DOTNET_INSTALL_DIR/shared/Microsoft.NETCore.App/$version"
     if [ ! -d "$sharedRuntimePath" ]; then
-        $scriptRoot/dotnet/dotnet-install.sh --shared-runtime --channel $channel --version $version
+        $scriptRoot/dotnet/dotnet-install.sh \
+            --shared-runtime \
+            --channel $channel \
+            --version $version \
+            --azure-feed $dotnet_azure_feed
+
+        if [ $? -ne 0 ]; then
+            exit 1
+        fi
     fi
 }
 
@@ -90,7 +119,14 @@ else
     export DOTNET_INSTALL_DIR=$DOTNET_INSTALL_DIR
     chmod +x $scriptRoot/dotnet/dotnet-install.sh
 
-    $scriptRoot/dotnet/dotnet-install.sh --channel $KOREBUILD_DOTNET_CHANNEL --version $KOREBUILD_DOTNET_VERSION
+    $scriptRoot/dotnet/dotnet-install.sh \
+        --channel $KOREBUILD_DOTNET_CHANNEL \
+        --version $KOREBUILD_DOTNET_VERSION \
+        --azure-feed $dotnet_azure_feed
+
+    if [ $? -ne 0 ]; then
+        exit 1
+    fi
 
     # Add .NET installation directory to the path if it isn't yet included.
     [[ ":$PATH:" != *":$DOTNET_INSTALL_DIR:"* ]] && export PATH="$DOTNET_INSTALL_DIR:$PATH"
@@ -114,19 +150,6 @@ ROOT_PATH=`dirname $DOTNET_PATH`
 FOUND=`find $ROOT_PATH/shared -name dotnet`
 if [ ! -z "$FOUND" ]; then
     echo $FOUND | xargs rm
-fi
-
-if [ "$(uname)" == "Darwin" ]; then
-    ulimit -n 2048
-
-    # Check that OS is 10.12 or newer
-    osx_version="$(sw_vers | grep ProductVersion | awk '{print $2}')"
-    minor_version="$(echo $osx_version | awk -F '.' '{print $2}')"
-    if [ $minor_version -lt 12 ]; then
-        echo -e "${RED}.NET Core 2.0 requires OSX 10.12 or newer. Current version is $osx_version.${RESET}"
-        exit 1
-    fi
-
 fi
 
 netfxversion='4.6.1'


### PR DESCRIPTION
Plus, exit korebuild's script sooner if dotnet download fails

