### PR TITLE
Add a canary test for KoreBuild

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+language: csharp
+sudo: false
+dist: trusty
+env:
+  global:
+    - DOTNET_SKIP_FIRST_TIME_EXPERIENCE=true
+    - DOTNET_CLI_TELEMETRY_OPTOUT=1
+mono: none
+os:
+  - linux
+  - osx
+osx_image: xcode8.2
+branches:
+  only:
+    - master
+    - release
+    - dev
+    - /^(.*\/)?ci-.*$/
+before_install:
+  - if test "$TRAVIS_OS_NAME" == "osx"; then brew update; brew install openssl; ln -s /usr/local/opt/openssl/lib/libcrypto.1.0.0.dylib /usr/local/lib/; ln -s /usr/local/opt/openssl/lib/libssl.1.0.0.dylib /usr/local/lib/; fi
+script:
+  - ./test/build-canary-repo.sh

--- a/README.md
+++ b/README.md
@@ -1,6 +1,20 @@
 KoreBuild
 =========
 
+[![Travis build status](https://img.shields.io/travis/aspnet/KoreBuild.svg?label=travis-ci&branch=dev&style=flat-square)](https://travis-ci.org/aspnet/KoreBuild/branches)
+[![AppVeyor build status](https://img.shields.io/appveyor/ci/aspnetci/KoreBuild/dev.svg?label=appveyor&style=flat-square)](https://ci.appveyor.com/project/aspnetci/KoreBuild/branch/dev)
+
 Build scripts for repos on https://github.com/aspnet.
 
 This project is part of ASP.NET Core. You can find samples, documentation and getting started instructions for ASP.NET Core at the [Home](https://github.com/aspnet/home) repo.
+
+## Testing
+
+This repository contains test scripts in the test/ folder.
+
+### build-canary-repo.{sh, ps1}
+
+This script will download a repository and use the local version of KoreBuild to build it.
+This serves as a canary test for the scripts but may not exercise all areas of KoreBuild.
+
+This defaults to using <https://github.com/aspnet/DependencyInjection.git> as the canary.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,18 @@
+init:
+  - git config --global core.autocrlf true
+branches:
+  only:
+    - master
+    - release
+    - dev
+    - /^(.*\/)?ci-.*$/
+environment:
+  global:
+    DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+    DOTNET_CLI_TELEMETRY_OPTOUT: 1
+build_script:
+  - ps: .\test\build-canary-repo.ps1
+clone_depth: 1
+test: off
+deploy: off
+os: Visual Studio 2017

--- a/test/build-canary-repo.ps1
+++ b/test/build-canary-repo.ps1
@@ -1,0 +1,24 @@
+<#
+.SYNOPSIS
+    Runs KoreBuild on a sample repository as a canary test
+.PARAMETER RepoUrl
+    The url of the repo to git clone and build with KoreBuild
+#>
+param(
+    [Alias("r")][string]$RepoUrl = 'https://github.com/aspnet/DependencyInjection.git')
+
+$ErrorActionPreference ='Stop'
+
+$workdir = "$PSScriptRoot/obj/"
+
+if (Test-Path $workdir) {
+    Remove-Item -Recurse -Force $workdir
+}
+
+if (!(Get-Command git -ErrorAction Ignore)) {
+    throw 'git is not available on the PATH'
+}
+
+& git clone -q $RepoUrl $workdir
+Copy-Item -Recurse "$PSScriptRoot/../build/" "$workdir/.build/"
+& $workdir/build.ps1

--- a/test/build-canary-repo.sh
+++ b/test/build-canary-repo.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+set -efo pipefail
+
+repo_url='https://github.com/aspnet/DependencyInjection.git'
+while [[ $# > 0 ]]; do
+    case $1 in
+        -r|--repo-url|-RepoUrl)
+            shift
+            repo_url=$1
+            ;;
+        -h|--help)
+            echo "Runs KoreBuild on a sample repository as a canary test"
+            echo ""
+            echo "Usage: $0 [-r|--repo-url <URL>]"
+            echo ""
+            echo "  -r|--repo-url     The url of the repo to git clone and build with KoreBuild"
+            exit 2
+            ;;
+        *)
+            echo "Unrecognized argument $1"
+            exit 1
+            ;;
+    esac
+    shift
+done
+
+script_root="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+workdir=$script_root/obj/
+rm -rf $workdir 2>/dev/null && :
+
+git clone $repo_url $workdir
+cp -R $script_root/../build/ $workdir/.build/
+$workdir/build.sh


### PR DESCRIPTION
Uses local Korebuild changes and runs a full build of aspnet/DependencyInjection as a canary test.

@Eilon can we enable appveyor and travis for this repo?