### PR TITLE
Revert to using cached feed and add curl retries

### DIFF
--- a/build/KoreBuild.sh
+++ b/build/KoreBuild.sh
@@ -57,9 +57,6 @@ cd $repoFolder
 
 scriptRoot="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-# The default azure feed used to download .NET Core CLI
-dotnet_azure_feed="https://dotnetcli.azureedge.net/dotnet"
-
 if [ "$(uname)" == "Darwin" ]; then
     ulimit -n 2048
 
@@ -69,12 +66,6 @@ if [ "$(uname)" == "Darwin" ]; then
     if [ $minor_version -lt 12 ]; then
         echo -e "${RED}.NET Core 2.0 requires OSX 10.12 or newer. Current version is $osx_version.${RESET}"
         exit 1
-    fi
-
-    if [ "$TRAVIS" = true ]; then
-        # Travis OSX agents consistently have networking issues pulling from dotnetcli.azureedge.net.
-        # This switches to using the "uncached feed"
-        dotnet_azure_feed="https://dotnetcli.blob.core.windows.net/dotnet"
     fi
 fi
 
@@ -97,8 +88,7 @@ install_shared_runtime() {
         $scriptRoot/dotnet/dotnet-install.sh \
             --shared-runtime \
             --channel $channel \
-            --version $version \
-            --azure-feed $dotnet_azure_feed
+            --version $version
 
         if [ $? -ne 0 ]; then
             exit 1
@@ -121,8 +111,7 @@ else
 
     $scriptRoot/dotnet/dotnet-install.sh \
         --channel $KOREBUILD_DOTNET_CHANNEL \
-        --version $KOREBUILD_DOTNET_VERSION \
-        --azure-feed $dotnet_azure_feed
+        --version $KOREBUILD_DOTNET_VERSION
 
     if [ $? -ne 0 ]; then
         exit 1

--- a/build/dotnet/dotnet-install.sh
+++ b/build/dotnet/dotnet-install.sh
@@ -512,10 +512,15 @@ download() {
     local out_path=${2:-}
 
     local failed=false
+    # Restart the request up to N times if it fails
+    local retries=3
+    # Give up after 120 seconds of retrying
+    local retry_max_time=120
+
     if [ -z "$out_path" ]; then
-        curl --fail -sSL $remote_path || failed=true
+        curl --fail --retry $retries --retry-max-time $retry_max_time -sSL $remote_path || failed=true
     else
-        curl --fail -sSL -o $out_path $remote_path || failed=true
+        curl --fail --retry $retries --retry-max-time $retry_max_time -sSL -o $out_path $remote_path || failed=true
     fi
 
     if [ "$failed" = true ]; then


### PR DESCRIPTION
Going back to using Azure CDN. We tried using the uncached feed, but this didn't succeed in mitigating issues. cref #205 

This adds retries to curl instead to see if we can workaround https://github.com/travis-ci/travis-ci/issues/7502