### PR TITLE
Disable xunit auto reporters when other test loggers are enabled

### DIFF
--- a/build/targets/KoreBuild.SolutionBuild.targets
+++ b/build/targets/KoreBuild.SolutionBuild.targets
@@ -289,7 +289,9 @@ Runs the VSTest on all projects in the ProjectsToTest itemgroup.
 -->
 
   <PropertyGroup>
-    <VSTestLogger Condition=" '$(VSTestLogger)' == '' AND '$(TEAMCITY_VERSION)' != '' ">trx</VSTestLogger>
+    <VSTestLogger Condition=" '$(VSTestLogger)' == '' AND '$(TEAMCITY_PROJECT_NAME)' != '' ">trx</VSTestLogger>
+    <!-- ensure AppVeyor's auto test reporter remaines enabled -->
+    <VSTestAutoReporters Condition="'$(APPVEYOR_API_URL)' != ''">true</VSTestAutoReporters>
     <IgnoreFailingTestProjects>false</IgnoreFailingTestProjects>
     <IgnoreFailingTestProjects Condition="'$(KOREBUILD_IGNORE_DOTNET_TEST_EXIT_CODE)' == '1'">true</IgnoreFailingTestProjects>
   </PropertyGroup>
@@ -304,7 +306,9 @@ Runs the VSTest on all projects in the ProjectsToTest itemgroup.
       Condition="'@(_TestProjectItems)' != ''" />
 
     <PropertyGroup>
-    <VSTestNoBuild Condition="'$(VSTestNoBuild)' == ''">$(_SolutionWasBuilt)</VSTestNoBuild>
+      <!-- diable other test reporters if trx logging is enabled -->
+      <TestRunSettings Condition=" '$(VSTestLogger)' != '' AND '$(VSTestAutoReporters)' != 'true' ">RunConfiguration.NoAutoReporters=true</TestRunSettings>
+      <VSTestNoBuild Condition="'$(VSTestNoBuild)' == ''">$(_SolutionWasBuilt)</VSTestNoBuild>
       <_TestContinueOnError Condition="'$(IgnoreFailingTestProjects)' == 'true'">ErrorAndContinue</_TestContinueOnError>
       <_TestContinueOnError Condition="'$(IgnoreFailingTestProjects)' != 'true'">ErrorAndStop</_TestContinueOnError>
     </PropertyGroup>
@@ -312,7 +316,7 @@ Runs the VSTest on all projects in the ProjectsToTest itemgroup.
     <!-- Intentional use of batching ('%') instead of passing items ('@') so that tests fail sooner -->
     <MSBuild Projects="%(_TestProjectItems.Identity)"
       Targets="VSTest"
-      Properties="$(_SolutionProperties);VSTestLogger=$(VSTestLogger);VSTestNoBuild=$(VSTestNoBuild)"
+      Properties="$(_SolutionProperties);VSTestLogger=$(VSTestLogger);VSTestNoBuild=$(VSTestNoBuild);VSTestCLIRunSettings=$(TestRunSettings)"
       Condition="'@(_TestProjectItems)' != ''"
       ContinueOnError="$(_TestContinueOnError)"
       RemoveProperties="$(_BuildPropertiesToRemove);_TestContinueOnError" />

--- a/build/targets/KoreBuild.SolutionBuild.targets
+++ b/build/targets/KoreBuild.SolutionBuild.targets
@@ -306,8 +306,8 @@ Runs the VSTest on all projects in the ProjectsToTest itemgroup.
       Condition="'@(_TestProjectItems)' != ''" />
 
     <PropertyGroup>
-      <!-- diable other test reporters if trx logging is enabled -->
-      <VSTestCLIRunSettings Condition=" '$(VSTestLogger)' != '' AND '$(VSTestAutoReporters)' != 'true' ">RunConfiguration.NoAutoReporters=true;$(VSTestCLIRunSettings)</VSTestCLIRunSettings>
+      <!-- disable other test reporters if trx logging is enabled -->
+      <VSTestCLIRunSettings Condition=" '$(VSTestAutoReporters)' != 'true' ">RunConfiguration.NoAutoReporters=true;$(VSTestCLIRunSettings)</VSTestCLIRunSettings>
       <VSTestNoBuild Condition="'$(VSTestNoBuild)' == ''">$(_SolutionWasBuilt)</VSTestNoBuild>
       <_TestContinueOnError Condition="'$(IgnoreFailingTestProjects)' == 'true'">ErrorAndContinue</_TestContinueOnError>
       <_TestContinueOnError Condition="'$(IgnoreFailingTestProjects)' != 'true'">ErrorAndStop</_TestContinueOnError>

--- a/build/targets/KoreBuild.SolutionBuild.targets
+++ b/build/targets/KoreBuild.SolutionBuild.targets
@@ -290,8 +290,8 @@ Runs the VSTest on all projects in the ProjectsToTest itemgroup.
 
   <PropertyGroup>
     <VSTestLogger Condition=" '$(VSTestLogger)' == '' AND '$(TEAMCITY_VERSION)' != '' ">trx</VSTestLogger>
-    <!-- ensure AppVeyor's auto test reporter remains enabled -->
-    <VSTestAutoReporters Condition="'$(APPVEYOR_API_URL)' != ''">true</VSTestAutoReporters>
+    <VSTestAutoReporters Condition=" '$(VSTestAutoReporters)' == '' AND '$(VSTestLogger)' != '' ">false</VSTestAutoReporters>
+    <VSTestAutoReporters Condition=" '$(VSTestAutoReporters)' == '' ">true</VSTestAutoReporters>
     <IgnoreFailingTestProjects>false</IgnoreFailingTestProjects>
     <IgnoreFailingTestProjects Condition="'$(KOREBUILD_IGNORE_DOTNET_TEST_EXIT_CODE)' == '1'">true</IgnoreFailingTestProjects>
   </PropertyGroup>

--- a/build/targets/KoreBuild.SolutionBuild.targets
+++ b/build/targets/KoreBuild.SolutionBuild.targets
@@ -289,8 +289,8 @@ Runs the VSTest on all projects in the ProjectsToTest itemgroup.
 -->
 
   <PropertyGroup>
-    <VSTestLogger Condition=" '$(VSTestLogger)' == '' AND '$(TEAMCITY_PROJECT_NAME)' != '' ">trx</VSTestLogger>
-    <!-- ensure AppVeyor's auto test reporter remaines enabled -->
+    <VSTestLogger Condition=" '$(VSTestLogger)' == '' AND '$(TEAMCITY_VERSION)' != '' ">trx</VSTestLogger>
+    <!-- ensure AppVeyor's auto test reporter remains enabled -->
     <VSTestAutoReporters Condition="'$(APPVEYOR_API_URL)' != ''">true</VSTestAutoReporters>
     <IgnoreFailingTestProjects>false</IgnoreFailingTestProjects>
     <IgnoreFailingTestProjects Condition="'$(KOREBUILD_IGNORE_DOTNET_TEST_EXIT_CODE)' == '1'">true</IgnoreFailingTestProjects>
@@ -307,7 +307,7 @@ Runs the VSTest on all projects in the ProjectsToTest itemgroup.
 
     <PropertyGroup>
       <!-- diable other test reporters if trx logging is enabled -->
-      <TestRunSettings Condition=" '$(VSTestLogger)' != '' AND '$(VSTestAutoReporters)' != 'true' ">RunConfiguration.NoAutoReporters=true</TestRunSettings>
+      <VSTestCLIRunSettings Condition=" '$(VSTestLogger)' != '' AND '$(VSTestAutoReporters)' != 'true' ">RunConfiguration.NoAutoReporters=true;$(VSTestCLIRunSettings)</VSTestCLIRunSettings>
       <VSTestNoBuild Condition="'$(VSTestNoBuild)' == ''">$(_SolutionWasBuilt)</VSTestNoBuild>
       <_TestContinueOnError Condition="'$(IgnoreFailingTestProjects)' == 'true'">ErrorAndContinue</_TestContinueOnError>
       <_TestContinueOnError Condition="'$(IgnoreFailingTestProjects)' != 'true'">ErrorAndStop</_TestContinueOnError>
@@ -316,7 +316,7 @@ Runs the VSTest on all projects in the ProjectsToTest itemgroup.
     <!-- Intentional use of batching ('%') instead of passing items ('@') so that tests fail sooner -->
     <MSBuild Projects="%(_TestProjectItems.Identity)"
       Targets="VSTest"
-      Properties="$(_SolutionProperties);VSTestLogger=$(VSTestLogger);VSTestNoBuild=$(VSTestNoBuild);VSTestCLIRunSettings=$(TestRunSettings)"
+      Properties="$(_SolutionProperties);VSTestLogger=$(VSTestLogger);VSTestNoBuild=$(VSTestNoBuild);VSTestCLIRunSettings=$(VSTestCLIRunSettings.Replace(';', '%3B'))"
       Condition="'@(_TestProjectItems)' != ''"
       ContinueOnError="$(_TestContinueOnError)"
       RemoveProperties="$(_BuildPropertiesToRemove);_TestContinueOnError" />


### PR DESCRIPTION
Right now CI shows duplicate test results

1. From TRX logger.
2. From xunit's TeamCity auto-reporter.

This will disable the auto-reporter in favor of TRX reporter.

**FYI**: this won't take effect until we upgrade to xunit 2.3. cref https://github.com/xunit/visualstudio.xunit/pull/108

Cons:

- TC auto reporter reports tests as they happen but TRX only happens when the test process is done and the .trx file is produced
- For new build configs, test results don't light up in TC unless you add the XML report processing feature. https://confluence.jetbrains.com/display/TCD10/XML+Report+Processing. We already have this enabled on all of our test configs.


Pros:

- Reduced console output.
- In some cases (e.g. parallel test runs), the TC reporter does not properly report tests. See #198 
- TRX reporter shows output that TC auto reporter does not. Example:  ![image](https://cloud.githubusercontent.com/assets/2696087/25298952/29caed14-26af-11e7-9754-87a99469b1b2.png)


