### PR TITLE
Change default dotnet install dir to USERPROFILE/.dotnet

### DIFF
--- a/build/KoreBuild.ps1
+++ b/build/KoreBuild.ps1
@@ -20,6 +20,7 @@ if (!$repoFolder) {
 Write-Host "Building $repoFolder"
 cd $repoFolder
 
+$dotnetArch = 'x64'
 $dotnetVersionFile = $PSScriptRoot + "\cli.version"
 $dotnetChannel = "preview"
 $dotnetVersion = Get-Content $dotnetVersionFile
@@ -47,7 +48,7 @@ if ($env:KOREBUILD_DOTNET_SHARED_RUNTIME_VERSION)
 $dotnetLocalInstallFolder = $env:DOTNET_INSTALL_DIR
 if (!$dotnetLocalInstallFolder)
 {
-    $dotnetLocalInstallFolder = "$env:LOCALAPPDATA\Microsoft\dotnet\"
+    $dotnetLocalInstallFolder = "$env:USERPROFILE\.dotnet\$dotnetArch\"
 }
 
 function InstallSharedRuntime([string] $version, [string] $channel)
@@ -56,7 +57,7 @@ function InstallSharedRuntime([string] $version, [string] $channel)
     # Avoid redownloading the CLI if it's already installed.
     if (!(Test-Path $sharedRuntimePath))
     {
-        & "$PSScriptRoot\dotnet\dotnet-install.ps1" -Channel $channel -SharedRuntime -Version $version -Architecture x64
+        & "$PSScriptRoot\dotnet\dotnet-install.ps1" -Channel $channel -SharedRuntime -Version $version -Architecture $dotnetArch
     }
 }
 
@@ -70,7 +71,7 @@ if ($env:KOREBUILD_SKIP_RUNTIME_INSTALL -eq "1")
 else
 {
     # Install the version of dotnet-cli used to compile
-    & "$PSScriptRoot\dotnet\dotnet-install.ps1" -Channel $dotnetChannel -Version $dotnetVersion -Architecture x64
+    & "$PSScriptRoot\dotnet\dotnet-install.ps1" -Channel $dotnetChannel -Version $dotnetVersion -Architecture $dotnetArch
 
     # Temporarily install these runtimes to prevent build breaks for repos not yet converted
     # 1.0.4 - for tools

--- a/build/KoreBuild.ps1
+++ b/build/KoreBuild.ps1
@@ -57,7 +57,11 @@ function InstallSharedRuntime([string] $version, [string] $channel)
     # Avoid redownloading the CLI if it's already installed.
     if (!(Test-Path $sharedRuntimePath))
     {
-        & "$PSScriptRoot\dotnet\dotnet-install.ps1" -Channel $channel -SharedRuntime -Version $version -Architecture $dotnetArch
+        & "$PSScriptRoot\dotnet\dotnet-install.ps1" -Channel $channel `
+            -SharedRuntime `
+            -Version $version `
+            -Architecture $dotnetArch `
+            -InstallDir $dotnetLocalInstallFolder
     }
 }
 
@@ -71,7 +75,10 @@ if ($env:KOREBUILD_SKIP_RUNTIME_INSTALL -eq "1")
 else
 {
     # Install the version of dotnet-cli used to compile
-    & "$PSScriptRoot\dotnet\dotnet-install.ps1" -Channel $dotnetChannel -Version $dotnetVersion -Architecture $dotnetArch
+    & "$PSScriptRoot\dotnet\dotnet-install.ps1" -Channel $dotnetChannel `
+        -Version $dotnetVersion `
+        -Architecture $dotnetArch `
+        -InstallDir $dotnetLocalInstallFolder
 
     # Temporarily install these runtimes to prevent build breaks for repos not yet converted
     # 1.0.4 - for tools


### PR DESCRIPTION
dotnet.exe in .NET Core 2.0 supports multi-level lookup using these rules:

Priority rank below (from 1 to 4):
1. Current working directory
 2. User directory
3. dotnet.exe directory
4. Global .NET directory

See [fx_muxer.cpp](https://github.com/dotnet/core-setup/blob/da184990929677a78c3936fb0abcfca44149c90d/src/corehost/cli/fxr/fx_muxer.cpp#L433-L439)

This means C:\program files\dotnet\dotnet.exe can find the versions of the SDK and shared FX installed to %USERPROFILE%\.dotnet. Setting this as the default install location via KoreBuild should reduce some friction when using VS.

![image](https://cloud.githubusercontent.com/assets/2696087/25362106/d0862ff2-2906-11e7-9393-9b2ecf4eaf09.png)
