### PR TITLE
Cleanup workarounds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,8 @@ PublishProfiles/
 *.cache
 *.docstates
 _ReSharper.*
-nuget.exe
+*.exe
+*.dll
 *net45.csproj
 *net451.csproj
 *k10.csproj

--- a/build/KoreBuild.ps1
+++ b/build/KoreBuild.ps1
@@ -122,5 +122,5 @@ if (!(Test-Path $msbuildArtifactsDir))
 
 $msBuildArguments | Out-File -Encoding ASCII -FilePath $msBuildResponseFile
 
-exec dotnet msbuild /nologo /t:Restore /p:PreflightRestore=true "$makeFileProj"
+exec dotnet msbuild /nologo /t:Restore /p:PreflightRestore=true /p:RepositoryRoot="$repoFolder/" "$makeFileProj"
 exec dotnet msbuild `@"$msBuildResponseFile"

--- a/build/KoreBuild.ps1
+++ b/build/KoreBuild.ps1
@@ -103,13 +103,22 @@ $msbuildArtifactsDir = "$repoFolder/artifacts/msbuild"
 $msbuildLogFilePath = "$msbuildArtifactsDir/msbuild.log"
 $msBuildResponseFile = "$msbuildArtifactsDir/msbuild.rsp"
 
+$preflightClpOption='/clp:DisableConsoleColor'
+$msbuildClpOption='/clp:DisableConsoleColor;Summary'
+if ("${env:CI}${env:APPVEYOR}${env:TEAMCITY_VERSION}${env:TRAVIS}" -eq "")
+{
+    # Not on any of the CI machines. Fine to use colors.
+    $preflightClpOption=''
+    $msbuildClpOption='/clp:Summary'
+}
+
 $msBuildArguments = @"
 /nologo
 /m
 /p:RepositoryRoot="$repoFolder/"
 /fl
 /flp:LogFile="$msbuildLogFilePath";Verbosity=detailed;Encoding=UTF-8
-/clp:Summary
+$msbuildClpOption
 "$makeFileProj"
 "@
 
@@ -122,5 +131,5 @@ if (!(Test-Path $msbuildArtifactsDir))
 
 $msBuildArguments | Out-File -Encoding ASCII -FilePath $msBuildResponseFile
 
-exec dotnet msbuild /nologo /t:Restore /p:PreflightRestore=true /p:RepositoryRoot="$repoFolder/" "$makeFileProj"
+exec dotnet msbuild /nologo $preflightClpOption /t:Restore /p:PreflightRestore=true "$makeFileProj"
 exec dotnet msbuild `@"$msBuildResponseFile"

--- a/build/KoreBuild.sh
+++ b/build/KoreBuild.sh
@@ -152,5 +152,5 @@ cat > $msbuildResponseFile <<ENDMSBUILDARGS
 ENDMSBUILDARGS
 echo -e "$msbuild_args" >> $msbuildResponseFile
 
-__exec dotnet msbuild /nologo /t:Restore /p:PreflightRestore=true /p:NetFxVersion=$netfxversion "$makeFileProj"
+__exec dotnet msbuild /nologo /t:Restore /p:PreflightRestore=true /p:NetFxVersion=$netfxversion /p:RepositoryRoot="$repoFolder/" "$makeFileProj"
 __exec dotnet msbuild @"$msbuildResponseFile"

--- a/template/version.props
+++ b/template/version.props
@@ -1,6 +1,7 @@
 <!-- This file may be overwritten by automation. Only values allowed here are VersionPrefix and VersionSuffix.  -->
 <Project>
     <PropertyGroup>
+        <!-- These values are just an example and not used in build. -->
         <VersionPrefix>1.2.0</VersionPrefix>
         <VersionSuffix>preview1</VersionSuffix>
     </PropertyGroup>


### PR DESCRIPTION
- No longer download NuGet.exe. Fixes #214
- Don't generate global.json
- ~~Don't suppress color output on CI.~~
- Add comments to template file. Fixes #222