### PR TITLE
Allow repos to pass additional properties to test projects

### DIFF
--- a/build/KoreBuild.proj
+++ b/build/KoreBuild.proj
@@ -12,7 +12,7 @@
       These properties include those that could interfere with inner builds
       or could result in an unnecessary build cache miss.
     -->
-    <_BuildPropertiesToRemove>$(_BuildPropertiesToRemove);TargetFramework;TargetFrameworks;RestoreGraphProjectInput;_InvalidConfigurationWarn;_InvalidConfigurationError</_BuildPropertiesToRemove>
+    <_BuildPropertiesToRemove>$(_BuildPropertiesToRemove);RestoreGraphProjectInput;_InvalidConfigurationWarn;_InvalidConfigurationError</_BuildPropertiesToRemove>
 
     <!--
       Extend the restore step to include multiple projects.

--- a/build/targets/KoreBuild.SolutionBuild.targets
+++ b/build/targets/KoreBuild.SolutionBuild.targets
@@ -152,9 +152,13 @@ Executes /t:{Target} on all solutions
 
     <Error Text="No solutions found to build in '$(RepositoryRoot)'" Condition="'@(_SolutionItems)' == ''" />
 
+    <!--
+      Added _SolutionTarget to invalidate subsequent MSBuild calls on the solution.
+      MSBuild incorrectly caches the "Clean" target.
+    -->
     <MSBuild Targets="Clean"
       Projects="@(_SolutionItems)"
-      Properties="$(_SolutionProperties)"
+      Properties="$(_SolutionProperties);_SolutionTarget=Clean"
       RemoveProperties="$(_BuildPropertiesToRemove)" />
   </Target>
 

--- a/build/targets/KoreBuild.SolutionBuild.targets
+++ b/build/targets/KoreBuild.SolutionBuild.targets
@@ -152,14 +152,9 @@ Executes /t:{Target} on all solutions
 
     <Error Text="No solutions found to build in '$(RepositoryRoot)'" Condition="'@(_SolutionItems)' == ''" />
 
-    <!--
-      Added _SolutionTarget to invalidate subsequent MSBuild calls on the solution.
-      MSBuild incorrectly caches the "Clean" target.
-      TODO remove when upgrading to MSBuild 15.2
-    -->
     <MSBuild Targets="Clean"
       Projects="@(_SolutionItems)"
-      Properties="$(_SolutionProperties);_SolutionTarget=Clean"
+      Properties="$(_SolutionProperties)"
       RemoveProperties="$(_BuildPropertiesToRemove)" />
   </Target>
 
@@ -316,10 +311,10 @@ Runs the VSTest on all projects in the ProjectsToTest itemgroup.
     <!-- Intentional use of batching ('%') instead of passing items ('@') so that tests fail sooner -->
     <MSBuild Projects="%(_TestProjectItems.Identity)"
       Targets="VSTest"
-      Properties="$(_SolutionProperties);VSTestLogger=$(VSTestLogger);VSTestNoBuild=$(VSTestNoBuild);VSTestCLIRunSettings=$(VSTestCLIRunSettings.Replace(';', '%3B'))"
+      Properties="$(_SolutionProperties);VSTestLogger=$(VSTestLogger);VSTestNoBuild=$(VSTestNoBuild);VSTestCLIRunSettings=$(VSTestCLIRunSettings.Replace(';', '%3B'));%(_TestProjectItems.AdditionalProperties)"
       Condition="'@(_TestProjectItems)' != ''"
       ContinueOnError="$(_TestContinueOnError)"
-      RemoveProperties="$(_BuildPropertiesToRemove);_TestContinueOnError" />
+      RemoveProperties="$(_BuildPropertiesToRemove)" />
 
   </Target>
 


### PR DESCRIPTION
Example usage:
```xml
<!-- in repo.targets -->
<Project>
  <ItemGroup>
     <!-- skip the net46 test run on AppVeyor -->
    <ProjectsToTest Update="$(RepositoryRoot)test\EFCore.SqlServer.FunctionalTests\*.csproj" Condition="'$(APPVEYOR)' == 'true'">
      <AdditionalProperties>TargetFramework=netcoreapp2.0</AdditionalProperties>
    </ProjectsToTest>
  </ItemGroup>
</Project>
```