### PR TITLE
Install CLI after installing shared runtimes

### DIFF
--- a/build/KoreBuild.ps1
+++ b/build/KoreBuild.ps1
@@ -74,12 +74,6 @@ if ($env:KOREBUILD_SKIP_RUNTIME_INSTALL -eq "1")
 }
 else
 {
-    # Install the version of dotnet-cli used to compile
-    & "$PSScriptRoot\dotnet\dotnet-install.ps1" -Channel $dotnetChannel `
-        -Version $dotnetVersion `
-        -Architecture $dotnetArch `
-        -InstallDir $dotnetLocalInstallFolder
-
     # Temporarily install these runtimes to prevent build breaks for repos not yet converted
     # 1.0.4 - for tools
     InstallSharedRuntime -version "1.0.4" -channel "preview"
@@ -90,6 +84,12 @@ else
     {
         InstallSharedRuntime -version $sharedRuntimeVersion -channel $sharedRuntimeChannel
     }
+
+    # Install the version of dotnet-cli used to compile
+    & "$PSScriptRoot\dotnet\dotnet-install.ps1" -Channel $dotnetChannel `
+        -Version $dotnetVersion `
+        -Architecture $dotnetArch `
+        -InstallDir $dotnetLocalInstallFolder
 }
 
 if (!($env:Path.Split(';') -icontains $dotnetLocalInstallFolder))

--- a/build/KoreBuild.sh
+++ b/build/KoreBuild.sh
@@ -104,6 +104,16 @@ else
     export DOTNET_INSTALL_DIR=$DOTNET_INSTALL_DIR
     chmod +x $scriptRoot/dotnet/dotnet-install.sh
 
+    # Temporarily install these runtimes to prevent build breaks for repos not yet converted
+    # 1.0.4 - for tools
+    install_shared_runtime "1.0.4" "preview"
+    # 1.1.1 - for test projects which haven't yet been converted to netcoreapp2.0
+    install_shared_runtime "1.1.1" "release/1.1.0"
+
+    if [ "$sharedRuntimeVersion" != "" ]; then
+        install_shared_runtime $KOREBUILD_DOTNET_SHARED_RUNTIME_VERSION $KOREBUILD_DOTNET_SHARED_RUNTIME_CHANNEL
+    fi
+
     $scriptRoot/dotnet/dotnet-install.sh \
         --channel $KOREBUILD_DOTNET_CHANNEL \
         --version $KOREBUILD_DOTNET_VERSION
@@ -114,16 +124,6 @@ else
 
     # Add .NET installation directory to the path if it isn't yet included.
     [[ ":$PATH:" != *":$DOTNET_INSTALL_DIR:"* ]] && export PATH="$DOTNET_INSTALL_DIR:$PATH"
-
-    # Temporarily install these runtimes to prevent build breaks for repos not yet converted
-    # 1.0.4 - for tools
-    install_shared_runtime "1.0.4" "preview"
-    # 1.1.1 - for test projects which haven't yet been converted to netcoreapp2.0
-    install_shared_runtime "1.1.1" "release/1.1.0"
-
-    if [ "$sharedRuntimeVersion" != "" ]; then
-        install_shared_runtime $KOREBUILD_DOTNET_SHARED_RUNTIME_VERSION $KOREBUILD_DOTNET_SHARED_RUNTIME_CHANNEL
-    fi
 fi
 
 netfxversion='4.6.1'


### PR DESCRIPTION
Currently `dotnet.exe` gets overwritten by the installation of shared runtimes which was the cause of the behavior where when after typing `dotnet` and pressing enter, it crashes. This re-order fixes it.