### PR TITLE
Use binary logging instead of plaintext file logging

### DIFF
--- a/build/KoreBuild.ps1
+++ b/build/KoreBuild.ps1
@@ -100,7 +100,7 @@ if (!($env:Path.Split(';') -icontains $dotnetLocalInstallFolder))
 
 $makeFileProj = "$PSScriptRoot/KoreBuild.proj"
 $msbuildArtifactsDir = "$repoFolder/artifacts/msbuild"
-$msbuildLogFilePath = "$msbuildArtifactsDir/msbuild.log"
+$msbuildLogFilePath = "$msbuildArtifactsDir/msbuild.binlog"
 $msBuildResponseFile = "$msbuildArtifactsDir/msbuild.rsp"
 
 
@@ -108,8 +108,7 @@ $msBuildArguments = @"
 /nologo
 /m
 /p:RepositoryRoot="$repoFolder/"
-/fl
-/flp:LogFile="$msbuildLogFilePath";Verbosity=detailed;Encoding=UTF-8
+/bl:"$msbuildLogFilePath"
 /clp:Summary
 "$makeFileProj"
 "@

--- a/build/KoreBuild.sh
+++ b/build/KoreBuild.sh
@@ -135,7 +135,7 @@ export ReferenceAssemblyRoot=$NUGET_PACKAGES/netframeworkreferenceassemblies/$ne
 makeFileProj="$scriptRoot/KoreBuild.proj"
 msbuildArtifactsDir="$repoFolder/artifacts/msbuild"
 msbuildResponseFile="$msbuildArtifactsDir/msbuild.rsp"
-msbuildLogFile="$msbuildArtifactsDir/msbuild.log"
+msbuildLogFile="$msbuildArtifactsDir/msbuild.binlog"
 
 if [ ! -f $msbuildArtifactsDir ]; then
     mkdir -p $msbuildArtifactsDir
@@ -145,8 +145,7 @@ cat > $msbuildResponseFile <<ENDMSBUILDARGS
 /nologo
 /m
 /p:RepositoryRoot="$repoFolder/"
-/fl
-/flp:LogFile="$msbuildLogFile";Verbosity=detailed;Encoding=UTF-8
+/bl:"$msbuildLogFile"
 /clp:Summary
 "$makeFileProj"
 ENDMSBUILDARGS


### PR DESCRIPTION
This will save us a huge chunk of disk space in our CI artifacts.

To view the log, open the \*.binlog file with https://github.com/KirillOsenkov/MSBuildStructuredLog

Close #225 