### PR TITLE
add support for converting log to structured log format

### DIFF
--- a/build/KoreBuild.proj
+++ b/build/KoreBuild.proj
@@ -6,6 +6,8 @@
     -->
     <TargetFramework>netcoreapp1.0</TargetFramework>
 
+    <StructuredLoggerVersion>1.0.130</StructuredLoggerVersion>
+
     <!--
       We want to ensure these properties do not flow into sub-builds.
       This group of properties should be specified in RemoveProperties when an MSBuild task is used.
@@ -35,6 +37,10 @@
       environment variable to compile for .NET Framework on xplat without installing Mono.
     -->
     <PackageReference Include="NETFrameworkReferenceAssemblies" Version="$(NetFxVersion)" Condition="'$(NetFxVersion)'!=''" />
+
+    <!-- MSBuild Structured Logger, which we use to optimize the binary log at the end (optionally) -->
+    <PackageReference Include="Microsoft.Build.Logging.StructuredLogger" Version="$(StructuredLoggerVersion)" />
+
     <!-- Additional package references required to make other targets work should be kept in the files where those targets are defined -->
   </ItemGroup>
 
@@ -55,6 +61,7 @@
   <Import Project="targets\KoreBuild.Common.targets" />
   <Import Project="targets\KoreBuild.SolutionItems.targets" Condition="'$(DisableDefaultItems)' != 'true'" />
   <Import Project="targets\KoreBuild.SolutionBuild.targets" Condition="'$(DisableDefaultTargets)' != 'true'" />
+  <Import Project="targets\KoreBuild.StructuredLogging.targets" />
 
   <Import Project="$(RepositoryRoot)build\repo.targets" Condition="Exists('$(RepositoryRoot)build\repo.targets')" />
 </Project>

--- a/build/KoreBuild.ps1
+++ b/build/KoreBuild.ps1
@@ -123,4 +123,20 @@ if (!(Test-Path $msbuildArtifactsDir))
 $msBuildArguments | Out-File -Encoding ASCII -FilePath $msBuildResponseFile
 
 __exec dotnet restore /p:PreflightRestore=true "$makeFileProj"
-__exec dotnet msbuild `@"$msBuildResponseFile"
+
+try {
+    __exec dotnet msbuild `@"$msBuildResponseFile"
+} finally {
+    # If the structured logger is enabled, replay the binary log to a structured log and remove the binary log
+    # (can't do this in MSBuild because MSBuild logs the log, for obvious reasons)
+    if ($env:KOREBUILD_WRITE_STRUCTURED_LOG -eq "true") {
+        # Open to suggestions for a cleaner way to do this...
+        $r = [regex]"!StructuredLoggerVersion:([^!]*)!"
+        $m = $r.Match((dotnet build $makeFileProj /t:GetStructuredLoggerVersion /p:DisableDefaultTargets=true))
+        $StructuredLoggerPath = "$env:USERPROFILE\.nuget\packages\microsoft.build.logging.structuredlogger\$($m.Groups[1].Value)\lib\netstandard1.5\StructuredLogger.dll"
+        $structuredLogPath = [IO.Path]::ChangeExtension($msbuildLogFilePath, ".buildlog")
+
+        Write-Host "Building structured log..."
+        __exec dotnet msbuild $msbuildLogFilePath /noconlog /logger:"StructuredLogger,$StructuredLoggerPath;$StructuredLogPath" /noautoresponse
+    }
+}

--- a/build/KoreBuild.sh
+++ b/build/KoreBuild.sh
@@ -153,3 +153,10 @@ echo -e "$msbuild_args" >> $msbuildResponseFile
 
 __exec dotnet restore /p:PreflightRestore=true /p:NetFxVersion=$netfxversion "$makeFileProj"
 __exec dotnet msbuild @"$msbuildResponseFile"
+
+if [ "$KOREBUILD_WRITE_STRUCTURED_LOG" == "true" ]; then
+    structuredLoggerVersion=$(dotnet build $makeFileProj /t:GetStructuredLoggerVersion /p:DisableDefaultTargets=true | grep "\!StructuredLoggerVersion" | sed 's/ *!StructuredLoggerVersion:\([^!]*\)!/\1/g')
+    structuredLogFile=${msbuildLogFile//.binlog/.buildlog}
+    structuredLoggerPath=$HOME/.nuget/packages/microsoft.build.logging.structuredlogger/$structuredLoggerVersion/lib/netstandard1.5/StructuredLogger.dll
+    __exec dotnet msbuild $msbuildLogFile /noconlog /logger:"StructuredLogger,$structuredLoggerPath;$structuredLogFile" /noautoresponse
+fi

--- a/build/targets/KoreBuild.StructuredLogging.targets
+++ b/build/targets/KoreBuild.StructuredLogging.targets
@@ -1,0 +1,5 @@
+<Project>
+  <Target Name="GetStructuredLoggerVersion">
+    <Message Text="!StructuredLoggerVersion:$(StructuredLoggerVersion)!" Importance="high" />
+  </Target>
+</Project>


### PR DESCRIPTION
This adds a post-build step to our build scripts to convert the `.binlog` MSBuild Binary log file to a `.buildlog` Structured log file. The resulting file is much smaller, and loads much quicker into the structured log viewer.

Note that we do not remove the `.binlog` file because the `.buildlog` file can't be replayed to a text file, so we need to keep the `.binlog` if we want that functionality.

Also, this is behind an environment variable trigger that I'll enable on the CI. It takes a good 40 seconds to run in Universe, and 10-15 seconds for some larger repos, so I think it's better to have it off by default. Devs can always process the log themselves on-demand.