### PR TITLE
Unset ErrorActionPreference when invoking another process

### DIFF
--- a/build/KoreBuild.ps1
+++ b/build/KoreBuild.ps1
@@ -5,8 +5,11 @@ param([parameter(ValueFromRemainingArguments=$true)][string[]] $allparams)
 function __exec($cmd) {
     $cmdName = [IO.Path]::GetFileName($cmd)
     Write-Host -ForegroundColor Cyan "> $cmdName $args"
+    $originalErrorPref = $ErrorActionPreference
+    $ErrorActionPreference = 'Continue'
     & $cmd @args
     $exitCode = $LASTEXITCODE
+    $ErrorActionPreference = $originalErrorPref
     if($exitCode -ne 0) {
         throw "'$cmdName $args' failed with exit code: $exitCode"
     }


### PR DESCRIPTION
This changes ErrorActionPreference before shell invoking a new process so that error is determined by exit code and not by output to stderr alone. This is a quirk of PowerShell. When `$ErrorActionPreference='Stop'`, any output to stderr is a fatal error and kills the process immediately.

Example: https://ci.appveyor.com/project/aspnetci/kestrelhttpserver/build/1.0.5373 got shortcircuited.
but https://ci.appveyor.com/project/aspnetci/kestrelhttpserver/build/1.0.5375 (run with this fix) allowed dotnet-test to complete.

