### PR TITLE
Updated shared runtimes to install to 1.0.5 & 1.1.2

### DIFF
--- a/build/KoreBuild.ps1
+++ b/build/KoreBuild.ps1
@@ -78,10 +78,10 @@ if ($env:KOREBUILD_SKIP_RUNTIME_INSTALL -eq "1")
 else
 {
     # Temporarily install these runtimes to prevent build breaks for repos not yet converted
-    # 1.0.4 - for tools
-    InstallSharedRuntime -version "1.0.4" -channel "preview"
-    # 1.1.1 - for test projects which haven't yet been converted to netcoreapp2.0
-    InstallSharedRuntime -version "1.1.1" -channel "release/1.1.0"
+    # 1.0.5 - for tools
+    InstallSharedRuntime -version "1.0.5" -channel "preview"
+    # 1.1.2 - for test projects which haven't yet been converted to netcoreapp2.0
+    InstallSharedRuntime -version "1.1.2" -channel "release/1.1.0"
 
     if ($sharedRuntimeVersion)
     {

--- a/build/KoreBuild.sh
+++ b/build/KoreBuild.sh
@@ -105,9 +105,9 @@ else
     chmod +x $scriptRoot/dotnet/dotnet-install.sh
 
     # Temporarily install these runtimes to prevent build breaks for repos not yet converted
-    # 1.0.4 - for tools
+    # 1.0.5 - for tools
     install_shared_runtime "1.0.4" "preview"
-    # 1.1.1 - for test projects which haven't yet been converted to netcoreapp2.0
+    # 1.1.2 - for test projects which haven't yet been converted to netcoreapp2.0
     install_shared_runtime "1.1.1" "release/1.1.0"
 
     if [ "$sharedRuntimeVersion" != "" ]; then


### PR DESCRIPTION
The latest CLI that the mirror is trying to use 6184, when seeing a netcoreapp1.1 tfm tries to find out a shared fx version of 1.1.2. (not sure if this is expected as shouldn't it fallback to the available 1.1 compatible runtimes?). I need this for the mirror to go through.