### PR TITLE
Added a common property to always use the latest shared runtime

### DIFF
--- a/build/targets/KoreBuild.Common.props
+++ b/build/targets/KoreBuild.Common.props
@@ -11,5 +11,6 @@
     <RepositoryRoot>$([MSBuild]::EnsureTrailingSlash('$(RepositoryRoot)'))</RepositoryRoot>
     <ArtifactsDir>$(RepositoryRoot)artifacts\</ArtifactsDir>
     <BuildDir>$(ArtifactsDir)build\</BuildDir>
+    <RuntimeFrameworkVersion Condition="'$(TargetFramework)'=='netcoreapp2.0'">2.0.0-*</RuntimeFrameworkVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Instead of changing all repos with this property, we could change it here and it seems to work. But I am not sure if this would have any other consequences.