### PR TITLE
Add support for repo tasks as a pre-build step

### DIFF
--- a/build/KoreBuild.proj
+++ b/build/KoreBuild.proj
@@ -51,6 +51,7 @@
   <Import Project="targets\KoreBuild.Common.props" />
   <Import Project="targets\KoreBuild.DefaultBuildSettings.props" Condition="'$(DisableDefaultBuildSettings)' != 'true'" />
   <Import Project="$(RepositoryRoot)build\repo.props" Condition="Exists('$(RepositoryRoot)build\repo.props')" />
+  <Import Project="$(RepositoryRoot)build\tasks\*.tasks" Condition="Exists('$(RepositoryRoot)build\tasks\')" />
 
   <Import Project="targets\KoreBuild.Common.targets" />
   <Import Project="targets\KoreBuild.SolutionItems.targets" Condition="'$(DisableDefaultItems)' != 'true'" />

--- a/build/KoreBuild.ps1
+++ b/build/KoreBuild.ps1
@@ -68,6 +68,22 @@ function InstallSharedRuntime([string] $version, [string] $channel)
     }
 }
 
+function BuildTaskProject {
+    $taskProj = "$repoFolder/build/tasks/RepoTasks.csproj"
+    $publishFolder = "$repoFolder/build/tasks/bin/publish/"
+
+    if (!(Test-Path $taskProj)) {
+        return
+    }
+
+    if (Test-Path $publishFolder) {
+        Remove-Item $publishFolder -Recurse -Force
+    }
+
+    __exec dotnet restore $taskProj
+    __exec dotnet publish $taskProj --configuration Release --output $publishFolder
+}
+
 $newPath = "$dotnetLocalInstallFolder;$env:PATH"
 if ($env:KOREBUILD_SKIP_RUNTIME_INSTALL -eq "1")
 {
@@ -125,5 +141,6 @@ if (!(Test-Path $msbuildArtifactsDir))
 
 $msBuildArguments | Out-File -Encoding ASCII -FilePath $msBuildResponseFile
 
+BuildTaskProject
 __exec dotnet restore /p:PreflightRestore=true "$makeFileProj"
 __exec dotnet msbuild `@"$msBuildResponseFile"

--- a/build/KoreBuild.sh
+++ b/build/KoreBuild.sh
@@ -91,6 +91,23 @@ install_shared_runtime() {
     fi
 }
 
+build_taskproject() {
+    local taskProj="$repoFolder/build/tasks/RepoTasks.csproj"
+    local publishFolder="$repoFolder/build/tasks/bin/publish/"
+
+    if [[ ! -f $taskProj ]]; then
+        # skipping
+        return
+    }
+
+    if [[ -d $publishFolder ]]; then
+        rm -rf $publishFolder
+    fi
+
+    __exec dotnet restore $taskProj
+    __exec dotnet publish $taskProj --configuration Release --output $publishFolder
+}
+
 if [ ! -z "$KOREBUILD_SKIP_RUNTIME_INSTALL" ]; then
     echo "Skipping runtime installation because KOREBUILD_SKIP_RUNTIME_INSTALL is set"
 
@@ -151,5 +168,6 @@ cat > $msbuildResponseFile <<ENDMSBUILDARGS
 ENDMSBUILDARGS
 echo -e "$msbuild_args" >> $msbuildResponseFile
 
+build_taskproject
 __exec dotnet restore /p:PreflightRestore=true /p:NetFxVersion=$netfxversion "$makeFileProj"
 __exec dotnet msbuild @"$msbuildResponseFile"


### PR DESCRIPTION
 - KoreBuild will automatically restore and compile build/tasks/RepoTasks.csproj
 - Added automatic import to build/tasks/\*.tasks

Resolves #254 

Example usage:
```
- build/
  - repo.targets
  - tasks/
    + RepoTasks.csproj
    + RepoTasks.tasks
    + TestTask.cs
```
```xml
<!-- RepoTasks.csproj -->
<Project Sdk="Microsoft.NET.Sdk">
  <PropertyGroup>
    <TargetFramework>netcoreapp2.0</TargetFramework>
  </PropertyGroup>

  <ItemGroup>
    <PackageReference Include="Microsoft.Build.Framework" Version="15.1.1012" PrivateAssets="All" />
    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="15.1.1012" PrivateAssets="All" />
    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.1.1012" PrivateAssets="All" />
  </ItemGroup>
</Project>
```
```xml
<!-- RepoTasks.tasks -->
<Project>
    <UsingTask TaskName="RepoTasks.TestTask" AssemblyFile="$(MSBuildThisFileDirectory)bin\publish\RepoTasks.dll" />
</Project>
```
```csharp
// TestTask.cs
using Microsoft.Build.Framework;
using Microsoft.Build.Utilities;

namespace RepoTasks
{
    public class TestTask : Task
    {
        public override bool Execute()
        {
            Log.LogMessage(MessageImportance.High, "Hello world!");
            return true;
        }
    }
}
```
```xml
<!-- repo.targets -->
<Project>
  <PropertyGroup>
    <PrepareDependsOn>$(PrepareDependsOn);TestMe</PrepareDependsOn>
  </PropertyGroup>

  <Target Name="TestMe">
    <TestTask />
  </Target>
</Project>
```