### PR TITLE
Make binary logging conditional

### DIFF
--- a/build/KoreBuild.ps1
+++ b/build/KoreBuild.ps1
@@ -119,15 +119,22 @@ if (!($env:Path.Split(';') -icontains $dotnetLocalInstallFolder))
 
 $makeFileProj = "$PSScriptRoot/KoreBuild.proj"
 $msbuildArtifactsDir = "$repoFolder/artifacts/msbuild"
-$msbuildLogFilePath = "$msbuildArtifactsDir/msbuild.binlog"
 $msBuildResponseFile = "$msbuildArtifactsDir/msbuild.rsp"
 
+$msBuildLogArgument = ""
+
+if ($env:KOREBUILD_ENABLE_BINARY_LOG -eq "1")
+{
+    Write-Host "Enabling binary logging because KOREBUILD_ENABLE_BINARY_LOG = 1"
+    $msbuildLogFilePath = "$msbuildArtifactsDir/msbuild.binlog"
+    $msBuildLogArgument = "/bl:$msbuildLogFilePath"
+}
 
 $msBuildArguments = @"
 /nologo
 /m
 /p:RepositoryRoot="$repoFolder/"
-/bl:"$msbuildLogFilePath"
+"$msBuildLogArgument"
 /clp:Summary
 "$makeFileProj"
 "@

--- a/build/KoreBuild.sh
+++ b/build/KoreBuild.sh
@@ -152,7 +152,13 @@ export ReferenceAssemblyRoot=$NUGET_PACKAGES/netframeworkreferenceassemblies/$ne
 makeFileProj="$scriptRoot/KoreBuild.proj"
 msbuildArtifactsDir="$repoFolder/artifacts/msbuild"
 msbuildResponseFile="$msbuildArtifactsDir/msbuild.rsp"
-msbuildLogFile="$msbuildArtifactsDir/msbuild.binlog"
+msBuildLogArgument=""
+
+if [ ! -z "$KOREBUILD_ENABLE_BINARY_LOG" ]; then
+    echo "Enabling binary logging because KOREBUILD_ENABLE_BINARY_LOG is set"
+    msBuildLogFile="$msbuildArtifactsDir/msbuild.binlog"
+    msBuildLogArgument="/bl:$msBuildLogFile"
+fi
 
 if [ ! -f $msbuildArtifactsDir ]; then
     mkdir -p $msbuildArtifactsDir
@@ -162,7 +168,7 @@ cat > $msbuildResponseFile <<ENDMSBUILDARGS
 /nologo
 /m
 /p:RepositoryRoot="$repoFolder/"
-/bl:"$msbuildLogFile"
+"$msBuildLogArgument"
 /clp:Summary
 "$makeFileProj"
 ENDMSBUILDARGS


### PR DESCRIPTION
It has terrible memory consumption especially on Ubuntu.
Ref: https://github.com/Microsoft/msbuild/issues/2168
It causes failures on Ubuntu https://github.com/Microsoft/msbuild/issues/2164

This PR makes it conditional
Set $env:KOREBUILD_ENABLE_BINARY_LOG=1 to enable logging.
