### PR TITLE
Allow source package to have props file

### DIFF
--- a/build/shared/sharedsources.csproj
+++ b/build/shared/sharedsources.csproj
@@ -8,6 +8,7 @@
   </Target>
 
   <Import Project="$(RepositoryRoot)build\common.props" Condition="Exists('$(RepositoryRoot)build\common.props')" />
+  <Import Project="$(NuspecBasePath)\sharedsources.props" Condition="Exists('$(NuspecBasePath)\sharedsources.props')" />
 
   <Target Name="WarnIfNoCommonProps" BeforeTargets="Pack">
     <Warning Text="Expected a props file in '$(RepositoryRoot)build\common.props'. Shared sources packages may be missing the right version number when this is left out."


### PR DESCRIPTION
Useful if for example you want to include source file from another location.