### PR TITLE
Add common properties and package reference for repo tasks projects

### DIFF
--- a/build/KoreBuild.ps1
+++ b/build/KoreBuild.ps1
@@ -80,8 +80,8 @@ function BuildTaskProject {
         Remove-Item $publishFolder -Recurse -Force
     }
 
-    __exec dotnet restore $taskProj
-    __exec dotnet publish $taskProj --configuration Release --output $publishFolder
+    __exec dotnet restore $taskProj "/p:RepoTasksSdkPath=$PSScriptRoot/Sdks/KoreBuild.RepoTasks/"
+    __exec dotnet publish $taskProj --configuration Release --output $publishFolder "/p:RepoTasksSdkPath=$PSScriptRoot/Sdks/KoreBuild.RepoTasks/"
 }
 
 $newPath = "$dotnetLocalInstallFolder;$env:PATH"

--- a/build/KoreBuild.sh
+++ b/build/KoreBuild.sh
@@ -104,8 +104,8 @@ build_taskproject() {
         rm -rf $publishFolder
     fi
 
-    __exec dotnet restore $taskProj
-    __exec dotnet publish $taskProj --configuration Release --output $publishFolder
+    __exec dotnet restore $taskProj "/p:RepoTasksSdkPath=$scriptRoot/Sdks/KoreBuild.RepoTasks/"
+    __exec dotnet publish $taskProj --configuration Release --output $publishFolder "/p:RepoTasksSdkPath=$scriptRoot/Sdks/KoreBuild.RepoTasks/"
 }
 
 if [ ! -z "$KOREBUILD_SKIP_RUNTIME_INSTALL" ]; then

--- a/build/Sdks/KoreBuild.RepoTasks/Sdk.props
+++ b/build/Sdks/KoreBuild.RepoTasks/Sdk.props
@@ -1,0 +1,18 @@
+<Project>
+
+  <PropertyGroup>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+
+    <!-- Set explicitly to make it clear that this is not a console app, even though it targets netcoreapp2.0 -->
+    <OutputType>library</OutputType>
+
+    <!--
+      The dependency versions here don't matter as long as the version is binary compatible with the version of MSBuild and NuGet
+      already embedded in Microsoft.NET.Sdk. These are essentially reference assemblies.
+    -->
+    <MSBuildPackagesVersion>15.3.0-preview-000388-01</MSBuildPackagesVersion>
+    <!-- Version must be less than or equal to what ships in with Microsoft.NET.Sdk. -->
+    <JsonInMSBuildVersion>9.0.1</JsonInMSBuildVersion>
+  </PropertyGroup>
+
+</Project>

--- a/build/Sdks/KoreBuild.RepoTasks/Sdk.targets
+++ b/build/Sdks/KoreBuild.RepoTasks/Sdk.targets
@@ -1,0 +1,12 @@
+<Project>
+
+  <ItemGroup>
+    <!-- set as private assets all since we don't need this in the publish output folder -->
+    <PackageReference Include="Microsoft.Build.Framework" Version="$(MSBuildPackagesVersion)" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MSBuildPackagesVersion)" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MSBuildPackagesVersion)" PrivateAssets="All" />
+    <!-- because almost everyone ends up using JSON in repo tasks -->
+    <PackageReference Include="Newtonsoft.Json" Version="$(JsonInMSBuildVersion)" PrivateAssets="All" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Reduce duplication in defining repo tasks projects.

Example usage:
```xml
<!-- build/tasks/RepoTasks.csproj -->
<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="$(RepoTasksSdkPath)\Sdk.props" Condition="'$(RepoTasksSdkPath)' != '' "/>

   <PropertyGroup>
       <!-- still required to keep Visual Studio and VS Code happy -->
       <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>

  <Import Project="$(RepoTasksSdkPath)\Sdk.targets" Condition="'$(RepoTasksSdkPath)' != '' "/>
</Project>
```